### PR TITLE
Nuevo DT para usar en AltaAlbum

### DIFF
--- a/Espotify/src/espotify/DataTypes/DTAlbum_SinDTArtista.java
+++ b/Espotify/src/espotify/DataTypes/DTAlbum_SinDTArtista.java
@@ -1,0 +1,81 @@
+package espotify.DataTypes;
+
+import java.util.List;
+
+public class DTAlbum_SinDTArtista {
+private String nombreAlbum;
+private int anioCreacion;
+private String fotoAlbum;
+private List<DTTemaGenerico> misTemas;
+private List<DTGenero>misGeneros;
+private String miArtista;
+
+    public DTAlbum_SinDTArtista() {
+    }
+
+    public DTAlbum_SinDTArtista(
+            String nombreAlbum, 
+            int anioCreacion, 
+            String fotoAlbum, 
+            List<DTTemaGenerico> misTemas,
+            List<DTGenero> misGeneros,
+            String miArtista
+    ) {
+        this.nombreAlbum = nombreAlbum;
+        this.anioCreacion = anioCreacion;
+        this.fotoAlbum = fotoAlbum;
+        this.misTemas = misTemas;
+        this.misGeneros = misGeneros;
+        this.miArtista = miArtista;
+    }
+
+    public String getNombreAlbum() {
+        return nombreAlbum;
+    }
+
+    public int getAnioCreacion() {
+        return anioCreacion;
+    }
+
+    public String getFotoAlbum() {
+        return fotoAlbum;
+    }
+
+    public List<DTTemaGenerico> getMisTemas() {
+        return misTemas;
+    }
+
+    public List<DTGenero> getMisgeneros() {
+        return misGeneros;
+    }
+
+    public String getMiArtista() {
+        return miArtista;
+    }
+
+    public void setNombreAlbum(String nombreAlbum) {
+        this.nombreAlbum = nombreAlbum;
+    }
+
+    public void setAnioCreacion(int anioCreacion) {
+        this.anioCreacion = anioCreacion;
+    }
+
+    public void setFotoAlbum(String fotoAlbum) {
+        this.fotoAlbum = fotoAlbum;
+    }
+
+    public void setMisTemas(List<DTTemaGenerico> misTemas) {
+        this.misTemas = misTemas;
+    }
+
+    public void setMisgeneros(List<DTGenero> misgeneros) {
+        this.misGeneros = misgeneros;
+    }
+
+    public void setMiArtista(String miArtista) {
+        this.miArtista = miArtista;
+    }
+    
+    
+}


### PR DESCRIPTION
Agregue un DT que contiene la informacion del album, los temas que contiene, sus generos y el nickname del artista al que pertenece. No modifique el DTAlbum ya creado para no generar conflictos con quienes pudieran estar utilizandolo.

No utilizo el DTAlbum ya creado porque no me sirve tener el DTArtista contenido dentro del album. Necesitaria construir todo el DTArtista antes de poder crear el DTAlbum y mandarlo a la operacion del controlador que se encarga del AltaAlbum, o alternativamente tener que mandar todo el DTArtista vacio salvo por el campo nickname, que es el unico que necesito para dar de alta el album.

Adicionalmente, creo que es innecesario tener DTArtista dentro de DTAlbum para el caso de uso Consulta Album, ya que no se pide tener los datos del artista en dicha consulta.