### PR TITLE
Agregue la relacion de generos hijos a Genero

### DIFF
--- a/Espotify/src/espotify/logica/Genero.java
+++ b/Espotify/src/espotify/logica/Genero.java
@@ -49,6 +49,15 @@ public class Genero implements Serializable{
     public void setMiPadre(Genero miPadre) {
         this.miPadre = miPadre;
     }
+    
+    public List<Genero> getMisSubgeneros() {
+        return this.misGenerosHijos;
+    }
+    
+    public void setMisSubgeneros(List<Genero> misSubgeneros) {
+        this.misGenerosHijos = misSubgeneros;
+    }
+    
     /*
     public List<Genero> getMisAlbumes() {
         return this.misAlbumes;


### PR DESCRIPTION
Probablemente tengan que borrar las tablas de la base de datos para que los cambios tomen efecto. Con esto se crea una nueva tabla Genero_Genero que contiene 2 columnas con los nombres de dos generos relacionados. Ambos campos son clave primaria, el segundo genero es clave foranea que hace referencia a la tabla Genero.