### PR TITLE
Correcciones varias

### DIFF
--- a/Espotify/src/espotify/DataTypes/DTAlbum_Simple.java
+++ b/Espotify/src/espotify/DataTypes/DTAlbum_Simple.java
@@ -9,6 +9,7 @@ private Long idAlbum;
 private String nombreAlbum;
 private int anioCreacion;
 private String nombreCompletoArtista;
+private List<String> generosDeAlbum;
 
     public DTAlbum_Simple() {
     }
@@ -20,6 +21,26 @@ private String nombreCompletoArtista;
         this.nombreCompletoArtista = nombreCompletoArtista;
     }
 
+    public DTAlbum_Simple(Long idAlbum, String nombreAlbum, int anioCreacion, String nombreCompletoArtista, List<String>generosDeAlbum) {
+        this.idAlbum = idAlbum;
+        this.nombreAlbum = nombreAlbum;
+        this.anioCreacion = anioCreacion;
+        this.nombreCompletoArtista = nombreCompletoArtista;
+        this.generosDeAlbum = generosDeAlbum;
+    } 
+
+    public List<String> getGenerosDeAlbum() {
+        return generosDeAlbum;
+    }
+
+    public void setGenerosDeAlbum(List<String> generosDeAlbum) {
+        this.generosDeAlbum = generosDeAlbum;
+    }
+    
+    public void setNuevoGeneroDeAlbum(String nombreGenero) {
+        this.generosDeAlbum.add(nombreAlbum);
+    }
+    
     public Long getIdAlbum() {
         return this.idAlbum;
     }

--- a/Espotify/src/espotify/DataTypes/DTArtista.java
+++ b/Espotify/src/espotify/DataTypes/DTArtista.java
@@ -1,6 +1,5 @@
 package espotify.DataTypes;
 
-import espotify.logica.Album;
 import java.util.Date;
 import java.util.List;
 
@@ -16,7 +15,17 @@ public class DTArtista extends DTUsuario{
     public DTArtista() {
         
     }
-    public DTArtista(String nickname, String nombreUsuario, String apellidoUsuario, String email, Date fecNac, String fotoPerfil, List<DTUsuario> misSeguidores, String biografia, String dirSitioWeb, List<DTAlbum> misAlbumesPublicados) {
+    public DTArtista(
+            String nickname, 
+            String nombreUsuario, 
+            String apellidoUsuario, 
+            String email, 
+            Date fecNac, 
+            String fotoPerfil, 
+            List<DTUsuario> misSeguidores, 
+            String biografia, 
+            String dirSitioWeb, 
+            List<DTAlbum> misAlbumesPublicados) {
         super(nickname,nombreUsuario,apellidoUsuario,email,fecNac,fotoPerfil);
         this.biografia = biografia;
         this.dirSitioWeb = dirSitioWeb;
@@ -49,5 +58,4 @@ public class DTArtista extends DTUsuario{
     public List<DTAlbum> getMisAlbumesPublicados() {
         return this.misAlbumesPublicados;
     }
-
 }

--- a/Espotify/src/espotify/DataTypes/DTCliente.java
+++ b/Espotify/src/espotify/DataTypes/DTCliente.java
@@ -1,6 +1,5 @@
 package espotify.DataTypes;
 
-import espotify.logica.Usuario;
 import java.util.Date;
 import java.util.List;
 public class DTCliente extends DTUsuario{

--- a/Espotify/src/espotify/DataTypes/DTTemaSimple.java
+++ b/Espotify/src/espotify/DataTypes/DTTemaSimple.java
@@ -1,5 +1,7 @@
 package espotify.DataTypes;
 
+import java.util.List;
+
 public class DTTemaSimple {
     
     private Long idTema;
@@ -8,7 +10,8 @@ public class DTTemaSimple {
     private int posicionEnAlbum;
     private String nombreAlbum;
     private String nombreCompletoArtista;
-
+    private List<String> generosDeTema;
+    
     public DTTemaSimple() {};
     
     public DTTemaSimple(Long idTema, String nombreTema, int duracionSegundos, int posicionEnAlbum, String nombreAlbum, String nombreCompletoArtista) {
@@ -20,6 +23,24 @@ public class DTTemaSimple {
         this.nombreCompletoArtista = nombreCompletoArtista;
     }
 
+    public DTTemaSimple(
+            Long idTema, 
+            String nombreTema, 
+            int duracionSegundos, 
+            int posicionEnAlbum, 
+            String nombreAlbum, 
+            String nombreCompletoArtista,
+            List<String> generosDeTema
+            ) {
+        this.idTema = idTema;
+        this.nombreTema = nombreTema;
+        this.duracionSegundos = duracionSegundos;
+        this.posicionEnAlbum = posicionEnAlbum;
+        this.nombreAlbum = nombreAlbum;
+        this.nombreCompletoArtista = nombreCompletoArtista;
+        this.generosDeTema = generosDeTema;
+    }
+    
     public Long getIdTema() {
         return idTema;
     }
@@ -77,5 +98,13 @@ public class DTTemaSimple {
                 + "] " + this.getNombreTema() + 
                 ", Album: " + this.getNombreAlbum() + 
                 ", Artista: " + this.getNombreCompletoArtista());
+    }
+
+    public List<String> getGenerosDeTema() {
+        return generosDeTema;
+    }
+
+    public void setGenerosDeTema(List<String> generosDeTema) {
+        this.generosDeTema = generosDeTema;
     }
 }

--- a/Espotify/src/espotify/DataTypes/DTUsuario.java
+++ b/Espotify/src/espotify/DataTypes/DTUsuario.java
@@ -1,6 +1,5 @@
 package espotify.DataTypes;
 
-import espotify.logica.Usuario;
 import java.util.Date;
 import java.util.List;
 

--- a/Espotify/src/espotify/logica/Album.java
+++ b/Espotify/src/espotify/logica/Album.java
@@ -5,6 +5,7 @@
 package espotify.logica;
 
 import espotify.DataTypes.DTAlbum;
+import espotify.DataTypes.DTAlbum_Simple;
 import espotify.DataTypes.DTGenero;
 import espotify.DataTypes.DTTemaConRuta;
 import espotify.DataTypes.DTTemaConURL;
@@ -82,6 +83,14 @@ public class Album implements Serializable {
         return misGeneros;
     }
 
+    public List<String> getMisGenerosString() {
+        List<String> generos = new ArrayList();
+        for (Genero g : this.getMisGeneros()) {
+            generos.add(g.getNombreGenero());
+        }
+        return generos;
+    }
+    
     public Usuario getMiArtista() {
         return miArtista;
     }
@@ -149,5 +158,15 @@ public class Album implements Serializable {
         }
         dta.setMisTemas(auxDTTG);
         return dta;
+    }
+    
+    public DTAlbum_Simple getDTAlbumSimple() {
+        return new DTAlbum_Simple(
+                this.getIdAlbum(),
+                this.getNombreAlbum(),
+                this.getAnioCreacion(),
+                this.getMiArtista().getNombreCompletoToString(),
+                this.getMisGenerosString()
+        );
     }
 }

--- a/Espotify/src/espotify/logica/Cliente.java
+++ b/Espotify/src/espotify/logica/Cliente.java
@@ -4,6 +4,7 @@
  */
 package espotify.logica;
 
+import espotify.DataTypes.DTCliente;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -126,19 +127,31 @@ public class Cliente extends Usuario{
     public List<ListaParticular> getMisListasReproduccionCreadas() {
         return this.misListasReproduccionCreadas;
     }
+    
     public void setMisListasReproduccionCreadas(ListaParticular lrc) {
         this.misListasReproduccionCreadas.addFirst(lrc);
     }
+    
     public void setMisListasReproduccionCreadasCompleta(List<ListaParticular> lrc) {
         this.misListasReproduccionCreadas = lrc;
     }
+    
     public void setPrivadafalse(String lista){ 
        for(ListaParticular lp:misListasReproduccionCreadas){
            if(lp.getNombreLista().equals(lista)){
                lp.setsoyPrivada(false);
            }
-       
        }
     }
 
+    public DTCliente getDTCliente() {
+        return new DTCliente(
+                this.getNickname(),
+                this.getNombreUsuario(),
+                this.getApellidoUsuario(),
+                this.getEmail(),
+                this.getFecNac(),
+                this.getFotoPerfil()
+        );
+    }
 }

--- a/Espotify/src/espotify/logica/Controlador.java
+++ b/Espotify/src/espotify/logica/Controlador.java
@@ -4,6 +4,8 @@ import espotify.DataTypes.DTGenero_Simple;
 import espotify.DataTypes.DTAlbum;
 import espotify.DataTypes.DTAlbum_Simple;
 import espotify.DataTypes.DTAlbum_SinDTArtista;
+import espotify.DataTypes.DTArtista;
+import espotify.DataTypes.DTCliente;
 import espotify.DataTypes.DTDatosArtista;
 import espotify.DataTypes.DTDatosCliente;
 import espotify.DataTypes.DTDatosListaReproduccion;
@@ -45,13 +47,13 @@ public class Controlador implements IControlador{
     }
     
     @Override
-    public void AltaArtista(Artista a){
-        this.contpersis.AltaArtista(a);
+    public void AltaArtista(DTArtista dtArtista){
+        this.contpersis.AltaArtista(dtArtista);
     }
   
     @Override
-    public void AltaCliente(Cliente c){
-        this.contpersis.AltaCliente(c);
+    public void AltaCliente(DTCliente dtCliente){
+        this.contpersis.AltaCliente(dtCliente);
     }
     
     @Override
@@ -164,15 +166,6 @@ public class Controlador implements IControlador{
     public void dejarDeSeguir(String C, String U){
         try {
             this.contpersis.dejarDeSeguir(C,U);
-        } catch (Exception ex) {
-            Logger.getLogger(Controlador.class.getName()).log(Level.SEVERE, null, ex);
-        }
-    }
-    
-    @Override
-    public void DejarDeSeguirPrueba() {
-        try {
-            this.contpersis.DejarDeSeguirPrueba();
         } catch (Exception ex) {
             Logger.getLogger(Controlador.class.getName()).log(Level.SEVERE, null, ex);
         }

--- a/Espotify/src/espotify/logica/Controlador.java
+++ b/Espotify/src/espotify/logica/Controlador.java
@@ -404,5 +404,20 @@ public class Controlador implements IControlador{
             Logger.getLogger(Controlador.class.getName()).log(Level.SEVERE, null, ex);
         }
     }
+    
+    @Override
+    public String getGeneroDeListaPorDefecto(String nombreListaRep) throws Exception {
+        try {
+            return this.contpersis.getGeneroDeListaPorDefecto(nombreListaRep);
+        } catch (Exception ex) {
+            throw ex;
+        }
+    }
+    
+    @Override
+    public ArrayList<DTAlbum_Simple> getDTAlbumesSimplePorGenero(String genero) {
+        return this.contpersis.getDTAlbumesSimplePorGenero(genero);
+    }
+
 }
 

--- a/Espotify/src/espotify/logica/IControlador.java
+++ b/Espotify/src/espotify/logica/IControlador.java
@@ -1,14 +1,10 @@
 package espotify.logica;
 
-
-import espotify.DataTypes.DTCliente;
-import espotify.DataTypes.DTDatosArtista;
-import espotify.DataTypes.DTDatosCliente;
-import espotify.DataTypes.DTListaReproduccion;
-
 import espotify.DataTypes.DTAlbum;
 import espotify.DataTypes.DTAlbum_Simple;
 import espotify.DataTypes.DTAlbum_SinDTArtista;
+import espotify.DataTypes.DTArtista;
+import espotify.DataTypes.DTCliente;
 import espotify.DataTypes.DTDatosArtista;
 import espotify.DataTypes.DTDatosCliente;
 import espotify.DataTypes.DTDatosListaReproduccion;
@@ -18,7 +14,6 @@ import espotify.DataTypes.DTTemaGenerico;
 import espotify.DataTypes.DTTemaSimple;
 import java.util.ArrayList;
 
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -26,8 +21,8 @@ public interface IControlador {
     public abstract ArrayList<String>getNicknamesArtistas();
     public abstract List<String>getNicknamesClientes();
     public abstract void AltaGenero(String nombreGenero, String nomPadre);
-    public abstract void AltaArtista(Artista a);
-    public abstract void AltaCliente(Cliente c);
+    public abstract void AltaArtista(DTArtista dtArtista);
+    public abstract void AltaCliente(DTCliente dtCliente);
     public abstract void AltaAlbum(DTAlbum_SinDTArtista dataAlbum) throws Exception;
 
     public abstract DTDatosArtista ConsultarPerfilArtista(String nicknameArtista);
@@ -41,7 +36,6 @@ public interface IControlador {
     public abstract void setSeguidorSeguido(String Seguidor, String Seguido);
     public abstract ArrayList<String> getSeguidosDeCliente(String nickname);
     public abstract void dejarDeSeguir(String C, String U);
-    public abstract void DejarDeSeguirPrueba();
     
     public abstract void CrearListaPorDefecto(String nombreLista, String fotoLista, String nombreGenero);
     public abstract void CrearListaParticular(String nombreLista, String fotoLista, String nicknameCliente, boolean esPrivada);

--- a/Espotify/src/espotify/logica/IControlador.java
+++ b/Espotify/src/espotify/logica/IControlador.java
@@ -13,7 +13,6 @@ import espotify.DataTypes.DTGenero_Simple;
 import espotify.DataTypes.DTTemaGenerico;
 import espotify.DataTypes.DTTemaSimple;
 import java.util.ArrayList;
-
 import java.util.List;
 import java.util.Map;
 
@@ -51,10 +50,12 @@ public interface IControlador {
     public abstract ArrayList<String> getNombresListasParticulares();
     public abstract ArrayList<String> getNombresListasParticularesPublicas();
     public abstract ArrayList<String> getNombresListasParticularesDeCliente(String nicknameCliente) throws Exception;
+    public abstract String getGeneroDeListaPorDefecto(String nombreListaRep) throws Exception;
     public abstract List<String> ConsultarNombresListasPorTipo(String tipoDeLista, String nickOgen);
     public abstract Map<Long, String> getAlbumesDisponibles();
     public abstract ArrayList<DTAlbum> getDTAlbumesDisponibles();
     public abstract ArrayList<DTAlbum_Simple> getDTAlbumesSimple();
+    public abstract ArrayList<DTAlbum_Simple> getDTAlbumesSimplePorGenero(String genero);
     public abstract ArrayList<DTGenero_Simple> getListaDTGeneroSimple();
     public abstract DTTemaGenerico getTemaPorLista(String nombreLista, String tipoDeLista, String nombreTema);
     public abstract List<DTGenero> getGenerosjTree();

--- a/Espotify/src/espotify/logica/Tema.java
+++ b/Espotify/src/espotify/logica/Tema.java
@@ -2,6 +2,7 @@ package espotify.logica;
 
 import espotify.DataTypes.DTTemaSimple;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
@@ -94,10 +95,12 @@ public abstract class Tema implements Serializable {
         
         String nombreArtista = "";
         String nombreAlbum = "";
+        List<String> generosDeTema = new ArrayList<>();
         
         if (this.getMiAlbum() != null && this.getMiAlbum().getMiArtista() != null) {
             nombreArtista = this.getMiAlbum().getMiArtista().getNombreCompletoToString();
             nombreAlbum = this.getMiAlbum().getNombreAlbum();
+            generosDeTema = this.getMiAlbum().getMisGenerosString();
         }
         
         return new DTTemaSimple(
@@ -106,7 +109,8 @@ public abstract class Tema implements Serializable {
                 this.getDuracionSegundos(),
                 this.getPosicionEnAlbum(),
                 nombreAlbum,
-                nombreArtista
+                nombreArtista,
+                generosDeTema
         );
     }
 }

--- a/Espotify/src/espotify/logica/Usuario.java
+++ b/Espotify/src/espotify/logica/Usuario.java
@@ -1,7 +1,3 @@
-/*
- * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
- * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
- */
 package espotify.logica;
 
 import java.util.List;
@@ -106,5 +102,5 @@ public abstract class Usuario implements Serializable{
     public String getNombreCompletoToString() {
         return (this.getNombreUsuario() + " " + this.getApellidoUsuario());
     }
-    
+
 }

--- a/Espotify/src/espotify/persistencia/ControladoraPersistencia.java
+++ b/Espotify/src/espotify/persistencia/ControladoraPersistencia.java
@@ -1,16 +1,10 @@
-
-/*
- * Click nbfs://nbhost/SystemFileSystem/Templates/Licenses/license-default.txt to change this license
- * Click nbfs://nbhost/SystemFileSystem/Templates/Classes/Class.java to edit this template
- */
 package espotify.persistencia;
-
-
-
 
 import espotify.DataTypes.DTAlbum;
 import espotify.DataTypes.DTAlbum_Simple;
 import espotify.DataTypes.DTAlbum_SinDTArtista;
+import espotify.DataTypes.DTArtista;
+import espotify.DataTypes.DTCliente;
 import espotify.DataTypes.DTGenero;
 import espotify.DataTypes.DTTemaConRuta;
 import espotify.DataTypes.DTTemaConURL;
@@ -74,17 +68,36 @@ public class ControladoraPersistencia {
         }
     }
 
-    public void AltaArtista(Artista u) {
+    public void AltaArtista(DTArtista dtArtista) {
         try {
-            this.artJpa.create(u);
+            Artista art = new Artista(
+                    dtArtista.getNickname(),
+                    dtArtista.getNombreUsuario(),
+                    dtArtista.getApellidoUsuario(),
+                    dtArtista.getEmail(),
+                    dtArtista.getFecNac(),
+                    dtArtista.getFotoPerfil(),
+                    dtArtista.getBiografia(),
+                    dtArtista.getDirSitioWeb()
+                    
+            );
+            this.artJpa.create(art);
         } catch (Exception ex) {
             Logger.getLogger(ControladoraPersistencia.class.getName()).log(Level.SEVERE, null, ex);
         }
     }
 
-    public void AltaCliente(Cliente c) {
+    public void AltaCliente(DTCliente dtCliente) {
         try {
-            this.cliJpa.create(c);
+            Cliente cli = new Cliente(
+                    dtCliente.getNickname(),
+                    dtCliente.getNombreUsuario(),
+                    dtCliente.getApellidoUsuario(),
+                    dtCliente.getEmail(),
+                    dtCliente.getFecNac(),
+                    dtCliente.getFotoPerfil()
+            );
+            this.cliJpa.create(cli);
         } catch (Exception ex) {
             Logger.getLogger(ControladoraPersistencia.class.getName()).log(Level.SEVERE, null, ex);
         }

--- a/Espotify/src/espotify/presentacion/AgregarTemaALista.form
+++ b/Espotify/src/espotify/presentacion/AgregarTemaALista.form
@@ -27,93 +27,109 @@
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="1" attributes="0">
-              <EmptySpace min="-2" pref="35" max="-2" attributes="0"/>
+              <EmptySpace min="-2" pref="33" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="1" attributes="0">
-                  <Component id="jLabel2" max="32767" attributes="0"/>
-                  <Component id="jLabel3" alignment="0" max="32767" attributes="0"/>
-                  <Component id="comboBoxListasOAlbums" alignment="0" pref="624" max="32767" attributes="0"/>
-                  <Component id="jScrollPane1" alignment="1" max="32767" attributes="0"/>
-                  <Component id="jSeparator2" alignment="0" max="32767" attributes="0"/>
-                  <Group type="102" alignment="0" attributes="0">
-                      <Component id="jLabel7" max="32767" attributes="0"/>
+                  <Component id="jSeparator1" max="32767" attributes="0"/>
+                  <Group type="102" attributes="0">
+                      <Group type="103" groupAlignment="1" max="-2" attributes="0">
+                          <Component id="jLabel6" max="32767" attributes="0"/>
+                          <Group type="102" alignment="1" attributes="0">
+                              <Group type="103" groupAlignment="0" attributes="0">
+                                  <Group type="102" alignment="1" attributes="0">
+                                      <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                                          <Component id="jLabel4" max="32767" attributes="0"/>
+                                          <Component id="jLabel1" pref="151" max="32767" attributes="0"/>
+                                      </Group>
+                                      <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                                  </Group>
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <Component id="jLabel5" min="-2" pref="151" max="-2" attributes="0"/>
+                                      <EmptySpace min="-2" pref="12" max="-2" attributes="0"/>
+                                  </Group>
+                              </Group>
+                              <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                                  <Component id="comboBoxTipoLista" pref="260" max="32767" attributes="0"/>
+                                  <Component id="comboBoxListasReproduccion" max="32767" attributes="0"/>
+                                  <Component id="comboBoxClientes" max="32767" attributes="0"/>
+                              </Group>
+                          </Group>
+                      </Group>
                       <EmptySpace type="separate" max="-2" attributes="0"/>
-                      <Component id="comboBoxTipoDeOrigenTema" max="32767" attributes="0"/>
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Component id="jLabel9" max="32767" attributes="0"/>
+                          <Component id="comboBoxTipoDeOrigenTema" alignment="0" max="32767" attributes="0"/>
+                          <Component id="jLabel2" alignment="0" max="32767" attributes="0"/>
+                          <Component id="comboBoxListasOAlbums" alignment="0" pref="0" max="32767" attributes="0"/>
+                      </Group>
+                  </Group>
+                  <Group type="102" attributes="0">
+                      <Component id="jLabel3" min="-2" pref="423" max="-2" attributes="0"/>
+                      <EmptySpace type="separate" max="-2" attributes="0"/>
+                      <Component id="jLabel8" max="32767" attributes="0"/>
                   </Group>
                   <Group type="102" alignment="0" attributes="0">
-                      <Component id="jLabel6" min="-2" pref="471" max="-2" attributes="0"/>
-                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
-                  </Group>
-                  <Group type="102" alignment="1" attributes="0">
-                      <EmptySpace min="-2" pref="50" max="-2" attributes="0"/>
-                      <Component id="btnCancelarAgregarTemaALista" min="-2" pref="205" max="-2" attributes="0"/>
-                      <EmptySpace max="32767" attributes="0"/>
-                      <Component id="btnConfirmarAgregarTemaALista" min="-2" pref="206" max="-2" attributes="0"/>
-                      <EmptySpace min="-2" pref="77" max="-2" attributes="0"/>
-                  </Group>
-                  <Group type="102" alignment="1" attributes="0">
+                      <Group type="103" groupAlignment="1" attributes="0">
+                          <Component id="btnCancelarAgregarTemaALista" min="-2" pref="250" max="-2" attributes="0"/>
+                          <Component id="jScrollPane1" min="-2" pref="423" max="-2" attributes="0"/>
+                      </Group>
+                      <EmptySpace type="separate" max="-2" attributes="0"/>
                       <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="jLabel4" alignment="0" max="32767" attributes="0"/>
-                          <Group type="102" alignment="0" attributes="0">
-                              <Component id="jLabel5" min="-2" pref="295" max="-2" attributes="0"/>
+                          <Component id="jScrollPane3" pref="400" max="32767" attributes="0"/>
+                          <Group type="102" attributes="0">
+                              <Component id="btnConfirmarAgregarTemaALista" min="-2" pref="250" max="-2" attributes="0"/>
                               <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
                           </Group>
-                          <Component id="jLabel1" alignment="1" max="32767" attributes="0"/>
-                      </Group>
-                      <EmptySpace type="unrelated" max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Group type="103" groupAlignment="0" max="-2" attributes="0">
-                              <Component id="comboBoxClientes" alignment="1" max="32767" attributes="0"/>
-                              <Component id="comboBoxTipoLista" min="-2" pref="278" max="-2" attributes="0"/>
-                          </Group>
-                          <Component id="comboBoxListasReproduccion" alignment="1" min="-2" pref="278" max="-2" attributes="0"/>
                       </Group>
                   </Group>
               </Group>
-              <EmptySpace min="-2" pref="26" max="-2" attributes="0"/>
+              <EmptySpace min="-2" pref="19" max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
     <DimensionLayout dim="1">
       <Group type="103" groupAlignment="0" attributes="0">
           <Group type="102" alignment="0" attributes="0">
-              <EmptySpace min="-2" pref="12" max="-2" attributes="0"/>
-              <Component id="jLabel6" min="-2" max="-2" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="1" attributes="0">
-                  <Component id="jLabel5" min="-2" max="-2" attributes="0"/>
-                  <Component id="comboBoxTipoLista" min="-2" max="-2" attributes="0"/>
+              <EmptySpace min="-2" pref="19" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="jLabel6" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="jLabel9" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
               <EmptySpace type="separate" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
-                  <Component id="comboBoxClientes" alignment="3" min="-2" max="-2" attributes="0"/>
-                  <Component id="jLabel4" alignment="3" min="-2" max="-2" attributes="0"/>
-              </Group>
-              <EmptySpace min="-2" pref="14" max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="3" attributes="0">
-                  <Component id="jLabel1" alignment="3" min="-2" max="-2" attributes="0"/>
-                  <Component id="comboBoxListasReproduccion" alignment="3" min="-2" max="-2" attributes="0"/>
-              </Group>
-              <EmptySpace type="separate" min="-2" max="-2" attributes="0"/>
-              <Component id="jSeparator2" min="-2" max="-2" attributes="0"/>
-              <EmptySpace max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="3" attributes="0">
-                  <Component id="jLabel7" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="jLabel5" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="comboBoxTipoLista" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="comboBoxTipoDeOrigenTema" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
               <EmptySpace type="separate" max="-2" attributes="0"/>
-              <Component id="jLabel2" min="-2" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="jLabel4" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="comboBoxClientes" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="jLabel2" alignment="3" min="-2" pref="24" max="-2" attributes="0"/>
+              </Group>
               <EmptySpace type="separate" max="-2" attributes="0"/>
-              <Component id="comboBoxListasOAlbums" min="-2" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="jLabel1" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="comboBoxListasReproduccion" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="comboBoxListasOAlbums" alignment="3" min="-2" max="-2" attributes="0"/>
+              </Group>
               <EmptySpace type="separate" max="-2" attributes="0"/>
-              <Component id="jLabel3" min="-2" max="-2" attributes="0"/>
-              <EmptySpace pref="30" max="32767" attributes="0"/>
-              <Component id="jScrollPane1" min="-2" pref="88" max="-2" attributes="0"/>
+              <Component id="jSeparator1" min="-2" pref="9" max="-2" attributes="0"/>
               <EmptySpace type="unrelated" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
-                  <Component id="btnConfirmarAgregarTemaALista" alignment="3" min="-2" max="-2" attributes="0"/>
-                  <Component id="btnCancelarAgregarTemaALista" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="jLabel3" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="jLabel8" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace min="-2" pref="16" max="-2" attributes="0"/>
+              <EmptySpace type="separate" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="0" attributes="0">
+                  <Component id="jScrollPane3" pref="124" max="32767" attributes="0"/>
+                  <Component id="jScrollPane1" pref="0" max="32767" attributes="0"/>
+              </Group>
+              <EmptySpace type="separate" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="btnCancelarAgregarTemaALista" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="btnConfirmarAgregarTemaALista" alignment="3" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace min="-2" pref="18" max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -162,12 +178,7 @@
     </Component>
     <Component class="javax.swing.JLabel" name="jLabel6">
       <Properties>
-        <Property name="text" type="java.lang.String" value="Seleccione la lista a la cual agregar el tema y el usuario si corresponde:"/>
-      </Properties>
-    </Component>
-    <Component class="javax.swing.JLabel" name="jLabel7">
-      <Properties>
-        <Property name="text" type="java.lang.String" value="Elija de donde seleccionar tema que desea agregar:"/>
+        <Property name="text" type="java.lang.String" value="Seleccione la lista a la cual agregar el tema:"/>
       </Properties>
     </Component>
     <Component class="javax.swing.JComboBox" name="comboBoxTipoDeOrigenTema">
@@ -188,8 +199,6 @@
       <AuxValues>
         <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
       </AuxValues>
-    </Component>
-    <Component class="javax.swing.JSeparator" name="jSeparator2">
     </Component>
     <Component class="javax.swing.JLabel" name="jLabel3">
       <Properties>
@@ -224,6 +233,9 @@
           <StringArray count="0"/>
         </Property>
       </Properties>
+      <Events>
+        <EventHandler event="itemStateChanged" listener="java.awt.event.ItemListener" parameters="java.awt.event.ItemEvent" handler="comboBoxListasReproduccionItemStateChanged"/>
+      </Events>
       <AuxValues>
         <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
       </AuxValues>
@@ -279,5 +291,37 @@
         </Component>
       </SubComponents>
     </Container>
+    <Component class="javax.swing.JLabel" name="jLabel8">
+      <Properties>
+        <Property name="text" type="java.lang.String" value="Temas de la lista seleccionada:"/>
+      </Properties>
+    </Component>
+    <Container class="javax.swing.JScrollPane" name="jScrollPane3">
+      <AuxValues>
+        <AuxValue name="autoScrollPane" type="java.lang.Boolean" value="true"/>
+      </AuxValues>
+
+      <Layout class="org.netbeans.modules.form.compat2.layouts.support.JScrollPaneSupportLayout"/>
+      <SubComponents>
+        <Component class="javax.swing.JList" name="jlistTemasDeListaSeleccionada">
+          <Properties>
+            <Property name="model" type="javax.swing.ListModel" editor="org.netbeans.modules.form.editors2.ListModelEditor">
+              <StringArray count="0"/>
+            </Property>
+            <Property name="selectionMode" type="int" value="0"/>
+          </Properties>
+          <AuxValues>
+            <AuxValue name="JavaCodeGenerator_TypeParameters" type="java.lang.String" value="&lt;String&gt;"/>
+          </AuxValues>
+        </Component>
+      </SubComponents>
+    </Container>
+    <Component class="javax.swing.JSeparator" name="jSeparator1">
+    </Component>
+    <Component class="javax.swing.JLabel" name="jLabel9">
+      <Properties>
+        <Property name="text" type="java.lang.String" value="Seleccione de donde desea elegir el tema:"/>
+      </Properties>
+    </Component>
   </SubComponents>
 </Form>

--- a/Espotify/src/espotify/presentacion/AgregarTemaALista.form
+++ b/Espotify/src/espotify/presentacion/AgregarTemaALista.form
@@ -26,45 +26,50 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" alignment="0" attributes="0">
+          <Group type="102" alignment="1" attributes="0">
               <EmptySpace min="-2" pref="35" max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="jLabel3" max="32767" attributes="0"/>
-                  <Group type="103" alignment="1" groupAlignment="1" attributes="0">
-                      <Group type="102" alignment="0" attributes="0">
-                          <EmptySpace min="-2" pref="54" max="-2" attributes="0"/>
-                          <Component id="btnCancelarAgregarTemaALista" min="-2" pref="205" max="-2" attributes="0"/>
-                          <EmptySpace min="-2" pref="68" max="-2" attributes="0"/>
-                          <Component id="btnConfirmarAgregarTemaALista" min="-2" pref="206" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="1" attributes="0">
+                  <Component id="jLabel2" max="32767" attributes="0"/>
+                  <Component id="jLabel3" alignment="0" max="32767" attributes="0"/>
+                  <Component id="comboBoxListasOAlbums" alignment="0" pref="624" max="32767" attributes="0"/>
+                  <Component id="jScrollPane1" alignment="1" max="32767" attributes="0"/>
+                  <Component id="jSeparator2" alignment="0" max="32767" attributes="0"/>
+                  <Group type="102" alignment="0" attributes="0">
+                      <Component id="jLabel7" max="32767" attributes="0"/>
+                      <EmptySpace type="separate" max="-2" attributes="0"/>
+                      <Component id="comboBoxTipoDeOrigenTema" max="32767" attributes="0"/>
+                  </Group>
+                  <Group type="102" alignment="0" attributes="0">
+                      <Component id="jLabel6" min="-2" pref="471" max="-2" attributes="0"/>
+                      <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                  </Group>
+                  <Group type="102" alignment="1" attributes="0">
+                      <EmptySpace min="-2" pref="50" max="-2" attributes="0"/>
+                      <Component id="btnCancelarAgregarTemaALista" min="-2" pref="205" max="-2" attributes="0"/>
+                      <EmptySpace max="32767" attributes="0"/>
+                      <Component id="btnConfirmarAgregarTemaALista" min="-2" pref="206" max="-2" attributes="0"/>
+                      <EmptySpace min="-2" pref="77" max="-2" attributes="0"/>
+                  </Group>
+                  <Group type="102" alignment="1" attributes="0">
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Component id="jLabel4" alignment="0" max="32767" attributes="0"/>
+                          <Group type="102" alignment="0" attributes="0">
+                              <Component id="jLabel5" min="-2" pref="295" max="-2" attributes="0"/>
+                              <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
+                          </Group>
+                          <Component id="jLabel1" alignment="1" max="32767" attributes="0"/>
                       </Group>
-                      <Group type="103" alignment="0" groupAlignment="0" max="-2" attributes="0">
-                          <Component id="jLabel2" alignment="0" max="32767" attributes="0"/>
-                          <Component id="jLabel6" alignment="0" min="-2" pref="471" max="-2" attributes="0"/>
-                          <Component id="jSeparator2" alignment="0" max="32767" attributes="0"/>
-                          <Group type="102" alignment="0" attributes="0">
-                              <Group type="103" groupAlignment="0" max="-2" attributes="0">
-                                  <Component id="jLabel1" max="32767" attributes="0"/>
-                                  <Component id="jLabel4" alignment="0" max="32767" attributes="0"/>
-                                  <Component id="jLabel5" alignment="0" min="-2" pref="295" max="-2" attributes="0"/>
-                              </Group>
-                              <EmptySpace type="unrelated" max="-2" attributes="0"/>
-                              <Group type="103" groupAlignment="0" max="-2" attributes="0">
-                                  <Component id="comboBoxClientes" alignment="1" max="32767" attributes="0"/>
-                                  <Component id="comboBoxListasReproduccion" max="32767" attributes="0"/>
-                                  <Component id="comboBoxTipoLista" min="-2" pref="278" max="-2" attributes="0"/>
-                              </Group>
+                      <EmptySpace type="unrelated" max="-2" attributes="0"/>
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                              <Component id="comboBoxClientes" alignment="1" max="32767" attributes="0"/>
+                              <Component id="comboBoxTipoLista" min="-2" pref="278" max="-2" attributes="0"/>
                           </Group>
-                          <Group type="102" alignment="0" attributes="0">
-                              <Component id="jLabel7" min="-2" pref="345" max="-2" attributes="0"/>
-                              <EmptySpace type="separate" max="-2" attributes="0"/>
-                              <Component id="comboBoxTipoDeOrigenTema" max="32767" attributes="0"/>
-                          </Group>
+                          <Component id="comboBoxListasReproduccion" alignment="1" min="-2" pref="278" max="-2" attributes="0"/>
                       </Group>
                   </Group>
-                  <Component id="comboBoxListasOAlbums" alignment="0" max="32767" attributes="0"/>
-                  <Component id="jScrollPane1" alignment="1" max="32767" attributes="0"/>
               </Group>
-              <EmptySpace min="-2" pref="65" max="-2" attributes="0"/>
+              <EmptySpace min="-2" pref="26" max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -104,9 +109,9 @@
               <EmptySpace pref="30" max="32767" attributes="0"/>
               <Component id="jScrollPane1" min="-2" pref="88" max="-2" attributes="0"/>
               <EmptySpace type="unrelated" max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="btnCancelarAgregarTemaALista" min="-2" max="-2" attributes="0"/>
-                  <Component id="btnConfirmarAgregarTemaALista" alignment="0" min="-2" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="btnConfirmarAgregarTemaALista" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="btnCancelarAgregarTemaALista" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
               <EmptySpace min="-2" pref="16" max="-2" attributes="0"/>
           </Group>
@@ -140,7 +145,7 @@
     </Component>
     <Component class="javax.swing.JButton" name="btnConfirmarAgregarTemaALista">
       <Properties>
-        <Property name="text" type="java.lang.String" value="Confirmar"/>
+        <Property name="text" type="java.lang.String" value="Agregar Tema"/>
         <Property name="selected" type="boolean" value="true"/>
       </Properties>
       <Events>
@@ -149,7 +154,7 @@
     </Component>
     <Component class="javax.swing.JButton" name="btnCancelarAgregarTemaALista">
       <Properties>
-        <Property name="text" type="java.lang.String" value="Cancelar"/>
+        <Property name="text" type="java.lang.String" value="Salir"/>
       </Properties>
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnCancelarAgregarTemaAListaActionPerformed"/>

--- a/Espotify/src/espotify/presentacion/AgregarTemaALista.form
+++ b/Espotify/src/espotify/presentacion/AgregarTemaALista.form
@@ -26,31 +26,32 @@
   <Layout>
     <DimensionLayout dim="0">
       <Group type="103" groupAlignment="0" attributes="0">
-          <Group type="102" alignment="1" attributes="0">
+          <Group type="102" alignment="0" attributes="0">
               <EmptySpace min="-2" pref="33" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="1" attributes="0">
-                  <Component id="jSeparator1" max="32767" attributes="0"/>
                   <Group type="102" attributes="0">
                       <Group type="103" groupAlignment="1" max="-2" attributes="0">
                           <Component id="jLabel6" max="32767" attributes="0"/>
                           <Group type="102" alignment="1" attributes="0">
                               <Group type="103" groupAlignment="0" attributes="0">
+                                  <Group type="102" alignment="0" attributes="0">
+                                      <Component id="jLabel5" min="-2" pref="151" max="-2" attributes="0"/>
+                                      <EmptySpace min="-2" pref="12" max="-2" attributes="0"/>
+                                  </Group>
                                   <Group type="102" alignment="1" attributes="0">
                                       <Group type="103" groupAlignment="0" max="-2" attributes="0">
                                           <Component id="jLabel4" max="32767" attributes="0"/>
                                           <Component id="jLabel1" pref="151" max="32767" attributes="0"/>
+                                          <Component id="jlabel7" max="32767" attributes="0"/>
                                       </Group>
                                       <EmptySpace type="unrelated" max="-2" attributes="0"/>
-                                  </Group>
-                                  <Group type="102" alignment="0" attributes="0">
-                                      <Component id="jLabel5" min="-2" pref="151" max="-2" attributes="0"/>
-                                      <EmptySpace min="-2" pref="12" max="-2" attributes="0"/>
                                   </Group>
                               </Group>
                               <Group type="103" groupAlignment="0" max="-2" attributes="0">
                                   <Component id="comboBoxTipoLista" pref="260" max="32767" attributes="0"/>
                                   <Component id="comboBoxListasReproduccion" max="32767" attributes="0"/>
                                   <Component id="comboBoxClientes" max="32767" attributes="0"/>
+                                  <Component id="labelGeneroDeLista" alignment="1" max="32767" attributes="0"/>
                               </Group>
                           </Group>
                       </Group>
@@ -62,23 +63,22 @@
                           <Component id="comboBoxListasOAlbums" alignment="0" pref="0" max="32767" attributes="0"/>
                       </Group>
                   </Group>
-                  <Group type="102" attributes="0">
-                      <Component id="jLabel3" min="-2" pref="423" max="-2" attributes="0"/>
-                      <EmptySpace type="separate" max="-2" attributes="0"/>
-                      <Component id="jLabel8" max="32767" attributes="0"/>
-                  </Group>
                   <Group type="102" alignment="0" attributes="0">
-                      <Group type="103" groupAlignment="1" attributes="0">
-                          <Component id="btnCancelarAgregarTemaALista" min="-2" pref="250" max="-2" attributes="0"/>
-                          <Component id="jScrollPane1" min="-2" pref="423" max="-2" attributes="0"/>
+                      <EmptySpace min="-2" pref="173" max="-2" attributes="0"/>
+                      <Component id="btnCancelarAgregarTemaALista" min="-2" pref="250" max="-2" attributes="0"/>
+                      <EmptySpace type="separate" max="-2" attributes="0"/>
+                      <Component id="btnConfirmarAgregarTemaALista" min="-2" pref="250" max="-2" attributes="0"/>
+                      <EmptySpace min="0" pref="150" max="32767" attributes="0"/>
+                  </Group>
+                  <Group type="102" attributes="0">
+                      <Group type="103" groupAlignment="0" attributes="0">
+                          <Component id="jLabel8" max="32767" attributes="0"/>
+                          <Component id="jScrollPane3" max="32767" attributes="0"/>
                       </Group>
                       <EmptySpace type="separate" max="-2" attributes="0"/>
-                      <Group type="103" groupAlignment="0" attributes="0">
-                          <Component id="jScrollPane3" pref="400" max="32767" attributes="0"/>
-                          <Group type="102" attributes="0">
-                              <Component id="btnConfirmarAgregarTemaALista" min="-2" pref="250" max="-2" attributes="0"/>
-                              <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
-                          </Group>
+                      <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                          <Component id="jLabel3" max="32767" attributes="0"/>
+                          <Component id="jScrollPane1" pref="399" max="32767" attributes="0"/>
                       </Group>
                   </Group>
               </Group>
@@ -112,24 +112,27 @@
                   <Component id="comboBoxListasReproduccion" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="comboBoxListasOAlbums" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace type="separate" max="-2" attributes="0"/>
-              <Component id="jSeparator1" min="-2" pref="9" max="-2" attributes="0"/>
-              <EmptySpace type="unrelated" max="-2" attributes="0"/>
-              <Group type="103" groupAlignment="3" attributes="0">
-                  <Component id="jLabel3" alignment="3" min="-2" max="-2" attributes="0"/>
-                  <Component id="jLabel8" alignment="3" min="-2" max="-2" attributes="0"/>
-              </Group>
-              <EmptySpace type="separate" max="-2" attributes="0"/>
+              <EmptySpace min="-2" pref="27" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="0" attributes="0">
-                  <Component id="jScrollPane3" pref="124" max="32767" attributes="0"/>
-                  <Component id="jScrollPane1" pref="0" max="32767" attributes="0"/>
+                  <Component id="jlabel7" min="-2" max="-2" attributes="0"/>
+                  <Component id="labelGeneroDeLista" min="-2" pref="18" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace pref="30" max="32767" attributes="0"/>
+              <Group type="103" groupAlignment="3" attributes="0">
+                  <Component id="jLabel8" alignment="3" min="-2" max="-2" attributes="0"/>
+                  <Component id="jLabel3" alignment="3" min="-2" max="-2" attributes="0"/>
+              </Group>
+              <EmptySpace type="unrelated" max="-2" attributes="0"/>
+              <Group type="103" groupAlignment="0" max="-2" attributes="0">
+                  <Component id="jScrollPane3" max="32767" attributes="0"/>
+                  <Component id="jScrollPane1" min="-2" pref="162" max="-2" attributes="0"/>
               </Group>
               <EmptySpace type="separate" max="-2" attributes="0"/>
               <Group type="103" groupAlignment="3" attributes="0">
                   <Component id="btnCancelarAgregarTemaALista" alignment="3" min="-2" max="-2" attributes="0"/>
                   <Component id="btnConfirmarAgregarTemaALista" alignment="3" min="-2" max="-2" attributes="0"/>
               </Group>
-              <EmptySpace min="-2" pref="18" max="-2" attributes="0"/>
+              <EmptySpace max="-2" attributes="0"/>
           </Group>
       </Group>
     </DimensionLayout>
@@ -316,12 +319,17 @@
         </Component>
       </SubComponents>
     </Container>
-    <Component class="javax.swing.JSeparator" name="jSeparator1">
-    </Component>
     <Component class="javax.swing.JLabel" name="jLabel9">
       <Properties>
         <Property name="text" type="java.lang.String" value="Seleccione de donde desea elegir el tema:"/>
       </Properties>
+    </Component>
+    <Component class="javax.swing.JLabel" name="jlabel7">
+      <Properties>
+        <Property name="text" type="java.lang.String" value="G&#xe9;nero de lista:"/>
+      </Properties>
+    </Component>
+    <Component class="javax.swing.JLabel" name="labelGeneroDeLista">
     </Component>
   </SubComponents>
 </Form>

--- a/Espotify/src/espotify/presentacion/AgregarTemaALista.java
+++ b/Espotify/src/espotify/presentacion/AgregarTemaALista.java
@@ -18,6 +18,7 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
     private DefaultComboBoxModel comboBoxDeListasModel = new DefaultComboBoxModel();
     private DefaultComboBoxModel comboBoxListasOAlbumsModel = new DefaultComboBoxModel();
     private DefaultListModel jlistTemasModel = new DefaultListModel();
+    private DefaultListModel temasDeListaSeleccionadaModel = new DefaultListModel();
     
     private final List<String> nicknamesClientes;
     private List<String> listaNombresDeListasGenericas;
@@ -51,9 +52,7 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
         btnConfirmarAgregarTemaALista = new javax.swing.JButton();
         btnCancelarAgregarTemaALista = new javax.swing.JButton();
         jLabel6 = new javax.swing.JLabel();
-        jLabel7 = new javax.swing.JLabel();
         comboBoxTipoDeOrigenTema = new javax.swing.JComboBox<>();
-        jSeparator2 = new javax.swing.JSeparator();
         jLabel3 = new javax.swing.JLabel();
         jLabel4 = new javax.swing.JLabel();
         comboBoxClientes = new javax.swing.JComboBox<>();
@@ -63,6 +62,11 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
         jLabel2 = new javax.swing.JLabel();
         jScrollPane1 = new javax.swing.JScrollPane();
         jlistTemas = new javax.swing.JList<>();
+        jLabel8 = new javax.swing.JLabel();
+        jScrollPane3 = new javax.swing.JScrollPane();
+        jlistTemasDeListaSeleccionada = new javax.swing.JList<>();
+        jSeparator1 = new javax.swing.JSeparator();
+        jLabel9 = new javax.swing.JLabel();
 
         setClosable(true);
         setIconifiable(true);
@@ -104,9 +108,7 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
             }
         });
 
-        jLabel6.setText("Seleccione la lista a la cual agregar el tema y el usuario si corresponde:");
-
-        jLabel7.setText("Elija de donde seleccionar tema que desea agregar:");
+        jLabel6.setText("Seleccione la lista a la cual agregar el tema:");
 
         comboBoxTipoDeOrigenTema.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "Seleccionar", "Lista por defecto", "Lista particular publica", "Album" }));
         comboBoxTipoDeOrigenTema.addItemListener(new java.awt.event.ItemListener() {
@@ -139,6 +141,12 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
             }
         });
 
+        comboBoxListasReproduccion.addItemListener(new java.awt.event.ItemListener() {
+            public void itemStateChanged(java.awt.event.ItemEvent evt) {
+                comboBoxListasReproduccionItemStateChanged(evt);
+            }
+        });
+
         jLabel1.setText("Lista de reproduccion:");
 
         comboBoxListasOAlbums.setEnabled(false);
@@ -156,82 +164,97 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
         jlistTemas.setEnabled(false);
         jScrollPane1.setViewportView(jlistTemas);
 
+        jLabel8.setText("Temas de la lista seleccionada:");
+
+        jlistTemasDeListaSeleccionada.setSelectionMode(javax.swing.ListSelectionModel.SINGLE_SELECTION);
+        jScrollPane3.setViewportView(jlistTemasDeListaSeleccionada);
+
+        jLabel9.setText("Seleccione de donde desea elegir el tema:");
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
         getContentPane().setLayout(layout);
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
-                .addGap(35, 35, 35)
+                .addGap(33, 33, 33)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                    .addComponent(jLabel2, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addComponent(jLabel3, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addComponent(comboBoxListasOAlbums, javax.swing.GroupLayout.Alignment.LEADING, 0, 624, Short.MAX_VALUE)
-                    .addComponent(jScrollPane1)
-                    .addComponent(jSeparator2, javax.swing.GroupLayout.Alignment.LEADING)
-                    .addGroup(javax.swing.GroupLayout.Alignment.LEADING, layout.createSequentialGroup()
-                        .addComponent(jLabel7, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                        .addGap(18, 18, 18)
-                        .addComponent(comboBoxTipoDeOrigenTema, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-                    .addGroup(javax.swing.GroupLayout.Alignment.LEADING, layout.createSequentialGroup()
-                        .addComponent(jLabel6, javax.swing.GroupLayout.PREFERRED_SIZE, 471, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addGap(0, 0, Short.MAX_VALUE))
+                    .addComponent(jSeparator1)
                     .addGroup(layout.createSequentialGroup()
-                        .addGap(50, 50, 50)
-                        .addComponent(btnCancelarAgregarTemaALista, javax.swing.GroupLayout.PREFERRED_SIZE, 205, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                        .addComponent(btnConfirmarAgregarTemaALista, javax.swing.GroupLayout.PREFERRED_SIZE, 206, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addGap(77, 77, 77))
-                    .addGroup(layout.createSequentialGroup()
-                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(jLabel4, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING, false)
+                            .addComponent(jLabel6, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                             .addGroup(layout.createSequentialGroup()
-                                .addComponent(jLabel5, javax.swing.GroupLayout.PREFERRED_SIZE, 295, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addGap(0, 0, Short.MAX_VALUE))
-                            .addComponent(jLabel1, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
-                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
+                                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                                            .addComponent(jLabel4, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                            .addComponent(jLabel1, javax.swing.GroupLayout.DEFAULT_SIZE, 151, Short.MAX_VALUE))
+                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED))
+                                    .addGroup(layout.createSequentialGroup()
+                                        .addComponent(jLabel5, javax.swing.GroupLayout.PREFERRED_SIZE, 151, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addGap(12, 12, 12)))
+                                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                                    .addComponent(comboBoxTipoLista, 0, 260, Short.MAX_VALUE)
+                                    .addComponent(comboBoxListasReproduccion, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                    .addComponent(comboBoxClientes, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))))
+                        .addGap(18, 18, 18)
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
-                                .addComponent(comboBoxClientes, javax.swing.GroupLayout.Alignment.TRAILING, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                                .addComponent(comboBoxTipoLista, javax.swing.GroupLayout.PREFERRED_SIZE, 278, javax.swing.GroupLayout.PREFERRED_SIZE))
-                            .addComponent(comboBoxListasReproduccion, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.PREFERRED_SIZE, 278, javax.swing.GroupLayout.PREFERRED_SIZE))))
-                .addGap(26, 26, 26))
+                            .addComponent(jLabel9, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                            .addComponent(comboBoxTipoDeOrigenTema, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                            .addComponent(jLabel2, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                            .addComponent(comboBoxListasOAlbums, 0, 1, Short.MAX_VALUE)))
+                    .addGroup(layout.createSequentialGroup()
+                        .addComponent(jLabel3, javax.swing.GroupLayout.PREFERRED_SIZE, 423, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addGap(18, 18, 18)
+                        .addComponent(jLabel8, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                    .addGroup(javax.swing.GroupLayout.Alignment.LEADING, layout.createSequentialGroup()
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                            .addComponent(btnCancelarAgregarTemaALista, javax.swing.GroupLayout.PREFERRED_SIZE, 250, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, 423, javax.swing.GroupLayout.PREFERRED_SIZE))
+                        .addGap(18, 18, 18)
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(jScrollPane3, javax.swing.GroupLayout.DEFAULT_SIZE, 400, Short.MAX_VALUE)
+                            .addGroup(layout.createSequentialGroup()
+                                .addComponent(btnConfirmarAgregarTemaALista, javax.swing.GroupLayout.PREFERRED_SIZE, 250, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addGap(0, 0, Short.MAX_VALUE)))))
+                .addGap(19, 19, 19))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
             .addGroup(layout.createSequentialGroup()
-                .addGap(12, 12, 12)
-                .addComponent(jLabel6)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                .addGap(19, 19, 19)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel6)
+                    .addComponent(jLabel9))
+                .addGap(18, 18, 18)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(jLabel5)
-                    .addComponent(comboBoxTipoLista, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addGap(18, 18, 18)
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(comboBoxClientes, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                    .addComponent(jLabel4))
-                .addGap(14, 14, 14)
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(jLabel1)
-                    .addComponent(comboBoxListasReproduccion, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addGap(18, 18, 18)
-                .addComponent(jSeparator2, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(jLabel7)
+                    .addComponent(comboBoxTipoLista, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(comboBoxTipoDeOrigenTema, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addGap(18, 18, 18)
-                .addComponent(jLabel2)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel4)
+                    .addComponent(comboBoxClientes, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(jLabel2, javax.swing.GroupLayout.PREFERRED_SIZE, 24, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addGap(18, 18, 18)
-                .addComponent(comboBoxListasOAlbums, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel1)
+                    .addComponent(comboBoxListasReproduccion, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                    .addComponent(comboBoxListasOAlbums, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addGap(18, 18, 18)
-                .addComponent(jLabel3)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 30, Short.MAX_VALUE)
-                .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, 88, javax.swing.GroupLayout.PREFERRED_SIZE)
+                .addComponent(jSeparator1, javax.swing.GroupLayout.PREFERRED_SIZE, 9, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(btnConfirmarAgregarTemaALista)
-                    .addComponent(btnCancelarAgregarTemaALista))
-                .addGap(16, 16, 16))
+                    .addComponent(jLabel3)
+                    .addComponent(jLabel8))
+                .addGap(18, 18, 18)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                    .addComponent(jScrollPane3, javax.swing.GroupLayout.DEFAULT_SIZE, 124, Short.MAX_VALUE)
+                    .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, 0, Short.MAX_VALUE))
+                .addGap(18, 18, 18)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(btnCancelarAgregarTemaALista)
+                    .addComponent(btnConfirmarAgregarTemaALista))
+                .addGap(18, 18, 18))
         );
 
         pack();
@@ -289,6 +312,7 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
                 comboBoxClientes.setEnabled(false);
                 comboBoxListasReproduccion.setEnabled(false);
             }
+            cargarTemasDeListaSeleccionada();
         }
     }//GEN-LAST:event_comboBoxTipoListaItemStateChanged
 
@@ -342,6 +366,7 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
                         "El tema fue agregado exitosamente a la lista.", 
                         "Operacion Exitosa", 
                         JOptionPane.INFORMATION_MESSAGE);
+                cargarTemasDeListaSeleccionada();
             } catch (Exception ex) {
                 JOptionPane.showMessageDialog(
                         null, 
@@ -353,6 +378,31 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
         
     }//GEN-LAST:event_btnConfirmarAgregarTemaAListaActionPerformed
 
+    private void cargarTemasDeListaSeleccionada() {
+        
+        temasDeListaSeleccionadaModel.removeAllElements();
+
+        if (comboBoxListasReproduccion.getSelectedItem() != null) {
+            String tipoDeLista = comboBoxTipoLista.getSelectedItem().toString();
+            String listaRep = comboBoxListasReproduccion.getSelectedItem().toString();
+            Map<Long, DTTemaSimple> temasDeLista;
+            
+            if (tipoDeLista.equals("Lista por defecto")) {
+                temasDeLista = controlador.getDTTemasDeListaPorDefecto(listaRep);
+            } else if (tipoDeLista.equals("Lista particular")) {
+                temasDeLista = controlador.getDTTemasDeListaParticular(listaRep);
+            } else {
+                return;
+            }
+            
+            for (Entry<Long, DTTemaSimple> dataTema : temasDeLista.entrySet()) {
+                temasDeListaSeleccionadaModel.addElement(dataTema.getValue().getDatosTemaToString());
+            }
+            
+            jlistTemasDeListaSeleccionada.setModel(temasDeListaSeleccionadaModel);
+        }
+    }
+    
     private void comboBoxTipoDeOrigenTemaItemStateChanged(java.awt.event.ItemEvent evt) {//GEN-FIRST:event_comboBoxTipoDeOrigenTemaItemStateChanged
         if (evt.getStateChange() == java.awt.event.ItemEvent.SELECTED) {
             comboBoxListasOAlbumsModel.removeAllElements();
@@ -477,6 +527,12 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
         }
     }//GEN-LAST:event_comboBoxClientesItemStateChanged
 
+    private void comboBoxListasReproduccionItemStateChanged(java.awt.event.ItemEvent evt) {//GEN-FIRST:event_comboBoxListasReproduccionItemStateChanged
+        if (evt.getStateChange() == java.awt.event.ItemEvent.SELECTED) {
+            cargarTemasDeListaSeleccionada();
+        }
+    }//GEN-LAST:event_comboBoxListasReproduccionItemStateChanged
+
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
     private javax.swing.JButton btnCancelarAgregarTemaALista;
@@ -492,9 +548,12 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
     private javax.swing.JLabel jLabel4;
     private javax.swing.JLabel jLabel5;
     private javax.swing.JLabel jLabel6;
-    private javax.swing.JLabel jLabel7;
+    private javax.swing.JLabel jLabel8;
+    private javax.swing.JLabel jLabel9;
     private javax.swing.JScrollPane jScrollPane1;
-    private javax.swing.JSeparator jSeparator2;
+    private javax.swing.JScrollPane jScrollPane3;
+    private javax.swing.JSeparator jSeparator1;
     private javax.swing.JList<String> jlistTemas;
+    private javax.swing.JList<String> jlistTemasDeListaSeleccionada;
     // End of variables declaration//GEN-END:variables
 }

--- a/Espotify/src/espotify/presentacion/AgregarTemaALista.java
+++ b/Espotify/src/espotify/presentacion/AgregarTemaALista.java
@@ -8,6 +8,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.DefaultListModel;
 import javax.swing.JOptionPane;
@@ -28,6 +30,7 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
     private Map<Long, String> mapTemas = new HashMap();
     private Map<Long, DTTemaSimple> mapDataTemas = new HashMap();
     private List<DTAlbum_Simple> listaDeDTAlbums;
+    private String generoDeListaSeleccionada = null;
     /**
      * Creates new form AgregarTemaALista
      */
@@ -65,8 +68,9 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
         jLabel8 = new javax.swing.JLabel();
         jScrollPane3 = new javax.swing.JScrollPane();
         jlistTemasDeListaSeleccionada = new javax.swing.JList<>();
-        jSeparator1 = new javax.swing.JSeparator();
         jLabel9 = new javax.swing.JLabel();
+        jlabel7 = new javax.swing.JLabel();
+        labelGeneroDeLista = new javax.swing.JLabel();
 
         setClosable(true);
         setIconifiable(true);
@@ -171,51 +175,54 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
 
         jLabel9.setText("Seleccione de donde desea elegir el tema:");
 
+        jlabel7.setText("Género de lista:");
+
         javax.swing.GroupLayout layout = new javax.swing.GroupLayout(getContentPane());
         getContentPane().setLayout(layout);
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
+            .addGroup(layout.createSequentialGroup()
                 .addGap(33, 33, 33)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                    .addComponent(jSeparator1)
                     .addGroup(layout.createSequentialGroup()
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING, false)
                             .addComponent(jLabel6, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                             .addGroup(layout.createSequentialGroup()
                                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                                    .addGroup(layout.createSequentialGroup()
+                                        .addComponent(jLabel5, javax.swing.GroupLayout.PREFERRED_SIZE, 151, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                        .addGap(12, 12, 12))
                                     .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
                                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
                                             .addComponent(jLabel4, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                                            .addComponent(jLabel1, javax.swing.GroupLayout.DEFAULT_SIZE, 151, Short.MAX_VALUE))
-                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED))
-                                    .addGroup(layout.createSequentialGroup()
-                                        .addComponent(jLabel5, javax.swing.GroupLayout.PREFERRED_SIZE, 151, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                        .addGap(12, 12, 12)))
+                                            .addComponent(jLabel1, javax.swing.GroupLayout.DEFAULT_SIZE, 151, Short.MAX_VALUE)
+                                            .addComponent(jlabel7, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)))
                                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
                                     .addComponent(comboBoxTipoLista, 0, 260, Short.MAX_VALUE)
                                     .addComponent(comboBoxListasReproduccion, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                                    .addComponent(comboBoxClientes, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))))
+                                    .addComponent(comboBoxClientes, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                    .addComponent(labelGeneroDeLista, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))))
                         .addGap(18, 18, 18)
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                             .addComponent(jLabel9, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                             .addComponent(comboBoxTipoDeOrigenTema, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                             .addComponent(jLabel2, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                             .addComponent(comboBoxListasOAlbums, 0, 1, Short.MAX_VALUE)))
-                    .addGroup(layout.createSequentialGroup()
-                        .addComponent(jLabel3, javax.swing.GroupLayout.PREFERRED_SIZE, 423, javax.swing.GroupLayout.PREFERRED_SIZE)
-                        .addGap(18, 18, 18)
-                        .addComponent(jLabel8, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
                     .addGroup(javax.swing.GroupLayout.Alignment.LEADING, layout.createSequentialGroup()
-                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                            .addComponent(btnCancelarAgregarTemaALista, javax.swing.GroupLayout.PREFERRED_SIZE, 250, javax.swing.GroupLayout.PREFERRED_SIZE)
-                            .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, 423, javax.swing.GroupLayout.PREFERRED_SIZE))
+                        .addGap(173, 173, 173)
+                        .addComponent(btnCancelarAgregarTemaALista, javax.swing.GroupLayout.PREFERRED_SIZE, 250, javax.swing.GroupLayout.PREFERRED_SIZE)
                         .addGap(18, 18, 18)
+                        .addComponent(btnConfirmarAgregarTemaALista, javax.swing.GroupLayout.PREFERRED_SIZE, 250, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addGap(0, 150, Short.MAX_VALUE))
+                    .addGroup(layout.createSequentialGroup()
                         .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                            .addComponent(jScrollPane3, javax.swing.GroupLayout.DEFAULT_SIZE, 400, Short.MAX_VALUE)
-                            .addGroup(layout.createSequentialGroup()
-                                .addComponent(btnConfirmarAgregarTemaALista, javax.swing.GroupLayout.PREFERRED_SIZE, 250, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addGap(0, 0, Short.MAX_VALUE)))))
+                            .addComponent(jLabel8, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                            .addComponent(jScrollPane3))
+                        .addGap(18, 18, 18)
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                            .addComponent(jLabel3, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                            .addComponent(jScrollPane1, javax.swing.GroupLayout.DEFAULT_SIZE, 399, Short.MAX_VALUE))))
                 .addGap(19, 19, 19))
         );
         layout.setVerticalGroup(
@@ -240,21 +247,23 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
                     .addComponent(jLabel1)
                     .addComponent(comboBoxListasReproduccion, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                     .addComponent(comboBoxListasOAlbums, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
-                .addGap(18, 18, 18)
-                .addComponent(jSeparator1, javax.swing.GroupLayout.PREFERRED_SIZE, 9, javax.swing.GroupLayout.PREFERRED_SIZE)
-                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
-                    .addComponent(jLabel3)
-                    .addComponent(jLabel8))
-                .addGap(18, 18, 18)
+                .addGap(27, 27, 27)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(jScrollPane3, javax.swing.GroupLayout.DEFAULT_SIZE, 124, Short.MAX_VALUE)
-                    .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, 0, Short.MAX_VALUE))
+                    .addComponent(jlabel7)
+                    .addComponent(labelGeneroDeLista, javax.swing.GroupLayout.PREFERRED_SIZE, 18, javax.swing.GroupLayout.PREFERRED_SIZE))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 30, Short.MAX_VALUE)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(jLabel8)
+                    .addComponent(jLabel3))
+                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                    .addComponent(jScrollPane3)
+                    .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, 162, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addGap(18, 18, 18)
                 .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
                     .addComponent(btnCancelarAgregarTemaALista)
                     .addComponent(btnConfirmarAgregarTemaALista))
-                .addGap(18, 18, 18))
+                .addContainerGap())
         );
 
         pack();
@@ -276,7 +285,9 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
         if (evt.getStateChange() == java.awt.event.ItemEvent.SELECTED) {
             comboBoxDeListasModel.removeAllElements();
             
-            if (comboBoxTipoLista.getSelectedItem().toString().equals("Lista particular")) {
+            String tipoDeLista = comboBoxTipoLista.getSelectedItem().toString();
+            
+            if (tipoDeLista.equals("Lista particular")) {
                 comboBoxListasReproduccion.setEnabled(true);
                 
                 if (comboBoxClientes.getSelectedItem() != null) {
@@ -297,8 +308,7 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
                     }
                 }
                 
-                
-            } else if (comboBoxTipoLista.getSelectedItem().toString().equals("Lista por defecto")){
+            } else if (tipoDeLista.equals("Lista por defecto")){
                 comboBoxListasReproduccion.setEnabled(true);
                 comboBoxClientes.setEnabled(false);
                 listaNombresDeListasGenericas = controlador.getNombresListasPorDefecto();
@@ -307,12 +317,20 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
                     comboBoxDeListasModel.addElement(nombreLista);
                 }
                 comboBoxListasReproduccion.setModel(comboBoxDeListasModel);
-                
             } else {
                 comboBoxClientes.setEnabled(false);
                 comboBoxListasReproduccion.setEnabled(false);
             }
-            cargarTemasDeListaSeleccionada();
+            
+            if (comboBoxListasReproduccion.getSelectedItem() == null) {
+                cargarTemasDeListaSeleccionada(tipoDeLista, null);
+                cargarGeneroDeListaPorDefecto(null);
+            } else {
+                String listaRep = comboBoxListasReproduccion.getSelectedItem().toString();
+                cargarTemasDeListaSeleccionada(tipoDeLista, listaRep);
+                cargarGeneroDeListaPorDefecto(listaRep);
+            }
+            cargarComboBoxListasOAlbums();
         }
     }//GEN-LAST:event_comboBoxTipoListaItemStateChanged
 
@@ -334,7 +352,7 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
     }
     
     private void btnConfirmarAgregarTemaAListaActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnConfirmarAgregarTemaAListaActionPerformed
-        
+           
         if (!validarSeleccion()) {
             JOptionPane.showMessageDialog(
                         null, 
@@ -366,7 +384,10 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
                         "El tema fue agregado exitosamente a la lista.", 
                         "Operacion Exitosa", 
                         JOptionPane.INFORMATION_MESSAGE);
-                cargarTemasDeListaSeleccionada();
+                
+                String tipoDeLista = comboBoxTipoLista.getSelectedItem().toString();         
+                cargarTemasDeListaSeleccionada(tipoDeLista, listaDestino);
+                
             } catch (Exception ex) {
                 JOptionPane.showMessageDialog(
                         null, 
@@ -375,16 +396,32 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
                         JOptionPane.ERROR_MESSAGE);
             }
         }
-        
     }//GEN-LAST:event_btnConfirmarAgregarTemaAListaActionPerformed
 
-    private void cargarTemasDeListaSeleccionada() {
+    private void cargarGeneroDeListaPorDefecto(String nombreLista) {
+        
+        if (nombreLista == null) {
+            generoDeListaSeleccionada = null;
+            labelGeneroDeLista.setText("");
+        } else {
+            try {
+                generoDeListaSeleccionada = controlador.getGeneroDeListaPorDefecto(nombreLista);
+                labelGeneroDeLista.setText(generoDeListaSeleccionada);
+            } catch (Exception ex) {
+                JOptionPane.showMessageDialog(
+                            null, 
+                            ex.getMessage(), 
+                            "Error", 
+                            JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+    
+    private void cargarTemasDeListaSeleccionada(String tipoDeLista, String listaRep) {
         
         temasDeListaSeleccionadaModel.removeAllElements();
 
-        if (comboBoxListasReproduccion.getSelectedItem() != null) {
-            String tipoDeLista = comboBoxTipoLista.getSelectedItem().toString();
-            String listaRep = comboBoxListasReproduccion.getSelectedItem().toString();
+        if (listaRep != null && tipoDeLista != null) {
             Map<Long, DTTemaSimple> temasDeLista;
             
             if (tipoDeLista.equals("Lista por defecto")) {
@@ -403,12 +440,11 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
         }
     }
     
-    private void comboBoxTipoDeOrigenTemaItemStateChanged(java.awt.event.ItemEvent evt) {//GEN-FIRST:event_comboBoxTipoDeOrigenTemaItemStateChanged
-        if (evt.getStateChange() == java.awt.event.ItemEvent.SELECTED) {
-            comboBoxListasOAlbumsModel.removeAllElements();
-            
+    private void cargarComboBoxListasOAlbums() {
+        comboBoxListasOAlbumsModel.removeAllElements();
+        
+        if (comboBoxTipoDeOrigenTema.getSelectedItem() != null) {
             if (comboBoxTipoDeOrigenTema.getSelectedItem().toString().equals("Lista particular publica")) {
-                
                 //habilito la seleccion del jlist
                 comboBoxListasOAlbums.setEnabled(true);
                 //obtengo las listas particulares publicas
@@ -430,7 +466,11 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
                 
             } else if (comboBoxTipoDeOrigenTema.getSelectedItem().toString().equals("Album")) {
                 comboBoxListasOAlbums.setEnabled(true);
-                listaDeDTAlbums = controlador.getDTAlbumesSimple();
+                if (generoDeListaSeleccionada == null) {
+                    listaDeDTAlbums = controlador.getDTAlbumesSimple();
+                } else {
+                    listaDeDTAlbums = controlador.getDTAlbumesSimplePorGenero(generoDeListaSeleccionada);
+                }
                 mapAlbums = new HashMap<Long, String>(listaDeDTAlbums.size());
                 
                 for (DTAlbum_Simple dtAlbum : listaDeDTAlbums) {
@@ -438,11 +478,16 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
                     comboBoxListasOAlbumsModel.addElement(dtAlbum.datosToString());
                 }
                 comboBoxListasOAlbums.setModel(comboBoxListasOAlbumsModel);
-                
             } else {
                 comboBoxListasOAlbums.setEnabled(false);
             }
             cargarTemas();
+        }
+    }
+    
+    private void comboBoxTipoDeOrigenTemaItemStateChanged(java.awt.event.ItemEvent evt) {//GEN-FIRST:event_comboBoxTipoDeOrigenTemaItemStateChanged
+        if (evt.getStateChange() == java.awt.event.ItemEvent.SELECTED) {
+            cargarComboBoxListasOAlbums();
         }
     }//GEN-LAST:event_comboBoxTipoDeOrigenTemaItemStateChanged
 
@@ -476,11 +521,23 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
             }
 
             mapTemas = new HashMap(mapDataTemas.size());
-
+            String tipoListaSeleccionada = null;
+            if (comboBoxListasReproduccion.getSelectedItem() != null) {
+                tipoListaSeleccionada = comboBoxTipoLista.getSelectedItem().toString();
+            }
+            
             for (Entry<Long, DTTemaSimple> entry : mapDataTemas.entrySet()) {
-                mapTemas.put(entry.getKey(), entry.getValue().getDatosTemaToString());
-                jlistTemasModel.addElement(entry.getValue().getDatosTemaToString());
-
+                Boolean listaSeleccionadaEsPorDefecto = tipoListaSeleccionada.equals("Lista por defecto");
+                if (listaSeleccionadaEsPorDefecto) {
+                    Boolean temaEsDeMismoGeneroQueLista = entry.getValue().getGenerosDeTema().contains(this.generoDeListaSeleccionada);
+                    if (temaEsDeMismoGeneroQueLista) {
+                        mapTemas.put(entry.getKey(), entry.getValue().getDatosTemaToString());
+                        jlistTemasModel.addElement(entry.getValue().getDatosTemaToString());
+                    }
+                } else {
+                    mapTemas.put(entry.getKey(), entry.getValue().getDatosTemaToString());
+                    jlistTemasModel.addElement(entry.getValue().getDatosTemaToString());
+                }
             }
 
             jlistTemas.setModel(jlistTemasModel);
@@ -524,12 +581,25 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
     private void comboBoxClientesItemStateChanged(java.awt.event.ItemEvent evt) {//GEN-FIRST:event_comboBoxClientesItemStateChanged
         if (evt.getStateChange() == java.awt.event.ItemEvent.SELECTED) {
             cargarComboBoxClientes();
+            if (comboBoxListasReproduccion.getSelectedItem() == null) {
+                cargarTemasDeListaSeleccionada(null, null);
+            }
         }
     }//GEN-LAST:event_comboBoxClientesItemStateChanged
 
     private void comboBoxListasReproduccionItemStateChanged(java.awt.event.ItemEvent evt) {//GEN-FIRST:event_comboBoxListasReproduccionItemStateChanged
         if (evt.getStateChange() == java.awt.event.ItemEvent.SELECTED) {
-            cargarTemasDeListaSeleccionada();
+            String tipoDeLista = comboBoxTipoLista.getSelectedItem().toString();
+            String listaRep = comboBoxListasReproduccion.getSelectedItem().toString();
+            
+            if (tipoDeLista.equals("Lista por defecto")) {
+                cargarGeneroDeListaPorDefecto(listaRep);
+            } else {
+                cargarGeneroDeListaPorDefecto(null);
+            }
+            
+            cargarTemasDeListaSeleccionada(tipoDeLista, listaRep);
+            cargarComboBoxListasOAlbums();
         }
     }//GEN-LAST:event_comboBoxListasReproduccionItemStateChanged
 
@@ -552,8 +622,9 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
     private javax.swing.JLabel jLabel9;
     private javax.swing.JScrollPane jScrollPane1;
     private javax.swing.JScrollPane jScrollPane3;
-    private javax.swing.JSeparator jSeparator1;
+    private javax.swing.JLabel jlabel7;
     private javax.swing.JList<String> jlistTemas;
     private javax.swing.JList<String> jlistTemasDeListaSeleccionada;
+    private javax.swing.JLabel labelGeneroDeLista;
     // End of variables declaration//GEN-END:variables
 }

--- a/Espotify/src/espotify/presentacion/AgregarTemaALista.java
+++ b/Espotify/src/espotify/presentacion/AgregarTemaALista.java
@@ -89,7 +89,7 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
             }
         });
 
-        btnConfirmarAgregarTemaALista.setText("Confirmar");
+        btnConfirmarAgregarTemaALista.setText("Agregar Tema");
         btnConfirmarAgregarTemaALista.setSelected(true);
         btnConfirmarAgregarTemaALista.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
@@ -97,7 +97,7 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
             }
         });
 
-        btnCancelarAgregarTemaALista.setText("Cancelar");
+        btnCancelarAgregarTemaALista.setText("Salir");
         btnCancelarAgregarTemaALista.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 btnCancelarAgregarTemaAListaActionPerformed(evt);
@@ -160,37 +160,41 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
         getContentPane().setLayout(layout);
         layout.setHorizontalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-            .addGroup(layout.createSequentialGroup()
+            .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createSequentialGroup()
                 .addGap(35, 35, 35)
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(jLabel3, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addGroup(javax.swing.GroupLayout.Alignment.TRAILING, layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                        .addGroup(javax.swing.GroupLayout.Alignment.LEADING, layout.createSequentialGroup()
-                            .addGap(54, 54, 54)
-                            .addComponent(btnCancelarAgregarTemaALista, javax.swing.GroupLayout.PREFERRED_SIZE, 205, javax.swing.GroupLayout.PREFERRED_SIZE)
-                            .addGap(68, 68, 68)
-                            .addComponent(btnConfirmarAgregarTemaALista, javax.swing.GroupLayout.PREFERRED_SIZE, 206, javax.swing.GroupLayout.PREFERRED_SIZE))
-                        .addGroup(javax.swing.GroupLayout.Alignment.LEADING, layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
-                            .addComponent(jLabel2, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                            .addComponent(jLabel6, javax.swing.GroupLayout.PREFERRED_SIZE, 471, javax.swing.GroupLayout.PREFERRED_SIZE)
-                            .addComponent(jSeparator2)
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
+                    .addComponent(jLabel2, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(jLabel3, javax.swing.GroupLayout.Alignment.LEADING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                    .addComponent(comboBoxListasOAlbums, javax.swing.GroupLayout.Alignment.LEADING, 0, 624, Short.MAX_VALUE)
+                    .addComponent(jScrollPane1)
+                    .addComponent(jSeparator2, javax.swing.GroupLayout.Alignment.LEADING)
+                    .addGroup(javax.swing.GroupLayout.Alignment.LEADING, layout.createSequentialGroup()
+                        .addComponent(jLabel7, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addGap(18, 18, 18)
+                        .addComponent(comboBoxTipoDeOrigenTema, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                    .addGroup(javax.swing.GroupLayout.Alignment.LEADING, layout.createSequentialGroup()
+                        .addComponent(jLabel6, javax.swing.GroupLayout.PREFERRED_SIZE, 471, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addGap(0, 0, Short.MAX_VALUE))
+                    .addGroup(layout.createSequentialGroup()
+                        .addGap(50, 50, 50)
+                        .addComponent(btnCancelarAgregarTemaALista, javax.swing.GroupLayout.PREFERRED_SIZE, 205, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                        .addComponent(btnConfirmarAgregarTemaALista, javax.swing.GroupLayout.PREFERRED_SIZE, 206, javax.swing.GroupLayout.PREFERRED_SIZE)
+                        .addGap(77, 77, 77))
+                    .addGroup(layout.createSequentialGroup()
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(jLabel4, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
                             .addGroup(layout.createSequentialGroup()
-                                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
-                                    .addComponent(jLabel1, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                                    .addComponent(jLabel4, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                                    .addComponent(jLabel5, javax.swing.GroupLayout.PREFERRED_SIZE, 295, javax.swing.GroupLayout.PREFERRED_SIZE))
-                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
-                                    .addComponent(comboBoxClientes, javax.swing.GroupLayout.Alignment.TRAILING, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                                    .addComponent(comboBoxListasReproduccion, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                                    .addComponent(comboBoxTipoLista, javax.swing.GroupLayout.PREFERRED_SIZE, 278, javax.swing.GroupLayout.PREFERRED_SIZE)))
-                            .addGroup(layout.createSequentialGroup()
-                                .addComponent(jLabel7, javax.swing.GroupLayout.PREFERRED_SIZE, 345, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addGap(18, 18, 18)
-                                .addComponent(comboBoxTipoDeOrigenTema, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))))
-                    .addComponent(comboBoxListasOAlbums, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
-                    .addComponent(jScrollPane1, javax.swing.GroupLayout.Alignment.TRAILING))
-                .addGap(65, 65, 65))
+                                .addComponent(jLabel5, javax.swing.GroupLayout.PREFERRED_SIZE, 295, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addGap(0, 0, Short.MAX_VALUE))
+                            .addComponent(jLabel1, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE))
+                        .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
+                        .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING, false)
+                                .addComponent(comboBoxClientes, javax.swing.GroupLayout.Alignment.TRAILING, 0, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                .addComponent(comboBoxTipoLista, javax.swing.GroupLayout.PREFERRED_SIZE, 278, javax.swing.GroupLayout.PREFERRED_SIZE))
+                            .addComponent(comboBoxListasReproduccion, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.PREFERRED_SIZE, 278, javax.swing.GroupLayout.PREFERRED_SIZE))))
+                .addGap(26, 26, 26))
         );
         layout.setVerticalGroup(
             layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -224,9 +228,9 @@ public class AgregarTemaALista extends javax.swing.JInternalFrame {
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 30, Short.MAX_VALUE)
                 .addComponent(jScrollPane1, javax.swing.GroupLayout.PREFERRED_SIZE, 88, javax.swing.GroupLayout.PREFERRED_SIZE)
                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.UNRELATED)
-                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
-                    .addComponent(btnCancelarAgregarTemaALista)
-                    .addComponent(btnConfirmarAgregarTemaALista))
+                .addGroup(layout.createParallelGroup(javax.swing.GroupLayout.Alignment.BASELINE)
+                    .addComponent(btnConfirmarAgregarTemaALista)
+                    .addComponent(btnCancelarAgregarTemaALista))
                 .addGap(16, 16, 16))
         );
 

--- a/Espotify/src/espotify/presentacion/AltaAlbum.form
+++ b/Espotify/src/espotify/presentacion/AltaAlbum.form
@@ -460,7 +460,7 @@
             </Component>
             <Component class="javax.swing.JButton" name="btnCancelarAltaAlbum">
               <Properties>
-                <Property name="text" type="java.lang.String" value="Cancelar"/>
+                <Property name="text" type="java.lang.String" value="Salir"/>
               </Properties>
               <Events>
                 <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnCancelarAltaAlbumActionPerformed"/>

--- a/Espotify/src/espotify/presentacion/AltaAlbum.java
+++ b/Espotify/src/espotify/presentacion/AltaAlbum.java
@@ -221,7 +221,7 @@ public class AltaAlbum extends javax.swing.JInternalFrame {
             }
         });
 
-        btnCancelarAltaAlbum.setText("Cancelar");
+        btnCancelarAltaAlbum.setText("Salir");
         btnCancelarAltaAlbum.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 btnCancelarAltaAlbumActionPerformed(evt);
@@ -591,7 +591,7 @@ public class AltaAlbum extends javax.swing.JInternalFrame {
         } catch (MalformedURLException | IllegalArgumentException e) {
             JOptionPane.showMessageDialog(
                         null, 
-                        "La url no es válida.", 
+                        "La url no es válida. Debe indicar el esquema (http/https) y el dominio.", 
                         "Error", 
                         JOptionPane.ERROR_MESSAGE); 
             return false;

--- a/Espotify/src/espotify/presentacion/AltaPerfil.java
+++ b/Espotify/src/espotify/presentacion/AltaPerfil.java
@@ -1,8 +1,9 @@
 package espotify.presentacion;
 
+import espotify.DataTypes.DTArtista;
+import espotify.DataTypes.DTCliente;
 import espotify.logica.Artista;
 import espotify.logica.Cliente;
-import espotify.logica.Controlador;
 import espotify.logica.Fabrica;
 import espotify.logica.IControlador;
 import java.awt.Image;
@@ -14,7 +15,6 @@ import java.nio.file.StandardCopyOption;
 import java.util.Date;
 import java.util.regex.Pattern;
 import javax.swing.ImageIcon;
-import javax.swing.JDialog;
 import javax.swing.JFileChooser;
 import javax.swing.JOptionPane;
 import javax.swing.filechooser.FileNameExtensionFilter;
@@ -297,31 +297,45 @@ public class AltaPerfil extends javax.swing.JInternalFrame {
         
         if (nickname.isEmpty()){
             JOptionPane.showMessageDialog(null, "El nickname esta vacio.", "Error", JOptionPane.ERROR_MESSAGE);
+            return;
         }
+        
         if(existeNicName){
             JOptionPane.showMessageDialog(null, "El nickname ya existe.", "Error", JOptionPane.ERROR_MESSAGE);
             jTextFieldnickname.setText("");
+            return;
         }
+        
         if (email.isEmpty()){
             JOptionPane.showMessageDialog(null, "El email esta vacio.", "Error", JOptionPane.ERROR_MESSAGE);
+            return;
         }
+        
         if(existeEmail){
             JOptionPane.showMessageDialog(null, "El email ya existe.", "Error", JOptionPane.ERROR_MESSAGE);
             jTextFieldemail.setText("");
+            return;
         }
+        
         if(!escorrectoEmail){
-                JOptionPane.showMessageDialog(null, "El mail no es correcto.", "Error", JOptionPane.ERROR_MESSAGE);
-                jTextFieldemail.setText("");
+            JOptionPane.showMessageDialog(null, "El mail no es correcto.", "Error", JOptionPane.ERROR_MESSAGE);
+            jTextFieldemail.setText("");
+            return;
         }
 
         if (nombre.isEmpty()){
             JOptionPane.showMessageDialog(null, "El nombre esta vacio.", "Error", JOptionPane.ERROR_MESSAGE);
+            return;
         }
+        
         if (apellido.isEmpty()){
             JOptionPane.showMessageDialog(null, "El apellido esta vacio.", "Error", JOptionPane.ERROR_MESSAGE);
+            return;
         }
+        
         if (fecNac == null) {
             JOptionPane.showMessageDialog(null, "La fecha de nacimiento esta vacio.", "Error", JOptionPane.ERROR_MESSAGE);
+            return;
         }
 
         boolean borrar = ((!nickname.isEmpty()) && (!nombre.isEmpty()) && (!apellido.isEmpty()) && (!email.isEmpty()) && (fecNac != null)&&(!existeNicName)&&(!existeEmail)&&(escorrectoEmail));
@@ -329,8 +343,19 @@ public class AltaPerfil extends javax.swing.JInternalFrame {
             if (opcion.equals("artista")) {
                 biografia = jTextAreaBiografia.getText();
                 webPromocion = jTextFieldwebpromocion.getText();
-                Artista a = new Artista(nickname, nombre, apellido, email, fecNac, fotoPerfil, biografia,webPromocion );
-                i.AltaArtista(a);
+                DTArtista dtArtista = new DTArtista(
+                        nickname, 
+                        nombre, 
+                        apellido, 
+                        email, 
+                        fecNac, 
+                        fotoPerfil,
+                        null,
+                        biografia, 
+                        webPromocion,
+                        null
+                );
+                i.AltaArtista(dtArtista);
                 
                 JOptionPane.showMessageDialog(this, 
                         "Artista creado exitosamente.",
@@ -338,8 +363,15 @@ public class AltaPerfil extends javax.swing.JInternalFrame {
                         JOptionPane.INFORMATION_MESSAGE);
             }
             if (opcion.equals("cliente")) {
-                Cliente c = new Cliente(nickname, nombre, apellido, email, fecNac, fotoPerfil);
-                i.AltaCliente(c);
+                DTCliente dtCliente = new DTCliente(
+                        nickname,
+                        nombre,
+                        apellido,
+                        email,
+                        fecNac,
+                        fotoPerfil
+                );
+                i.AltaCliente(dtCliente);
                 
                 JOptionPane.showMessageDialog(this, 
                         "Cliente creado exitosamente.",

--- a/Espotify/src/espotify/presentacion/QuitarTemaDeLista.form
+++ b/Espotify/src/espotify/presentacion/QuitarTemaDeLista.form
@@ -132,7 +132,7 @@
     </Component>
     <Component class="javax.swing.JButton" name="btnCancelar">
       <Properties>
-        <Property name="text" type="java.lang.String" value="Cancelar"/>
+        <Property name="text" type="java.lang.String" value="Salir"/>
       </Properties>
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnCancelarActionPerformed"/>
@@ -140,7 +140,7 @@
     </Component>
     <Component class="javax.swing.JButton" name="btnConfirmar">
       <Properties>
-        <Property name="text" type="java.lang.String" value="Confirmar"/>
+        <Property name="text" type="java.lang.String" value="Remover tema"/>
       </Properties>
       <Events>
         <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnConfirmarActionPerformed"/>

--- a/Espotify/src/espotify/presentacion/QuitarTemaDeLista.java
+++ b/Espotify/src/espotify/presentacion/QuitarTemaDeLista.java
@@ -79,14 +79,14 @@ public class QuitarTemaDeLista extends javax.swing.JInternalFrame {
 
         jLabel5.setText("Seleccione el tema que desea remover:");
 
-        btnCancelar.setText("Cancelar");
+        btnCancelar.setText("Salir");
         btnCancelar.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 btnCancelarActionPerformed(evt);
             }
         });
 
-        btnConfirmar.setText("Confirmar");
+        btnConfirmar.setText("Remover tema");
         btnConfirmar.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 btnConfirmarActionPerformed(evt);


### PR DESCRIPTION
- Arregle AltaPerfil para que no cree una instancia de objeto logico en capa de presentacion.
- Agregue un return vacio luego de cada joptionpane de altaperfil para que la funcion termine luego de un mensaje de error y no se muestren todos uno tras otro.
- Cambios en GUIs de AgregarTemaALista y QuitarTemaDeLista.
- Ahora AgregarTemaALista muestra los temas que estan en la lista que se esta modificando
- Ahora en AgregarTemaALista, cuando se selecciona una lista por defecto, solo se muestran para agregar los temas o albums que sean del mismo genero que la lista.
- Removi codigo del metodo quitarTemaDeLista del controlador de persistencia que se habia reintroducido erroneamente en un commit previo.
- Agregue en DTAlbum_Simple un atributo con los nombres de generos del album.
- Agregue en DTTemaSimple un atributo con los nombres de generos del album al que pertenecen.
- Agregue en Album un metodo que devuelve un DTAlbum_Simple con sus datos y asi simplificar la creacion del datatype en los controladores.
- Agregue en Cliente un metodo que devuelve un DTCliente con sus datos.
- Agregue 2 nuevas operaciones al controlador, una para obtener el genero de una lista de reproduccion por defecto y otra para obtener los albums que pertenecen a un genero recibido por parametro.
- Modifique el texto de unos botones y errores en mis GUIs para que sea mas claro de entender.