### PR TITLE
Modificacion de GUI alta perfil

### DIFF
--- a/Espotify/src/espotify/presentacion/AltaPerfil.form
+++ b/Espotify/src/espotify/presentacion/AltaPerfil.form
@@ -78,6 +78,7 @@
                       <Component id="jLabelBiografia" min="-2" max="-2" attributes="0"/>
                       <Component id="jLabelwebpromocion" alignment="0" min="-2" max="-2" attributes="0"/>
                       <Component id="jLabelcontrasena" min="-2" max="-2" attributes="0"/>
+                      <Component id="buttonCancelar" min="-2" max="-2" attributes="0"/>
                   </Group>
                   <EmptySpace min="-2" pref="34" max="-2" attributes="0"/>
                   <Group type="103" groupAlignment="0" attributes="0">
@@ -96,18 +97,20 @@
                           <EmptySpace min="-2" pref="92" max="-2" attributes="0"/>
                       </Group>
                       <Group type="102" alignment="0" attributes="0">
-                          <Group type="103" groupAlignment="1" attributes="0">
-                              <Group type="102" attributes="0">
-                                  <Component id="buttonAceptar" min="-2" max="-2" attributes="0"/>
-                                  <EmptySpace min="-2" pref="155" max="-2" attributes="0"/>
-                                  <Component id="buttonCancelar" min="-2" max="-2" attributes="0"/>
+                          <EmptySpace min="-2" pref="76" max="-2" attributes="0"/>
+                          <Group type="103" groupAlignment="1" max="-2" attributes="0">
+                              <Group type="102" alignment="0" attributes="0">
+                                  <EmptySpace min="-2" pref="80" max="-2" attributes="0"/>
+                                  <Component id="btnSalir" min="-2" pref="77" max="-2" attributes="0"/>
+                                  <EmptySpace max="32767" attributes="0"/>
+                                  <Component id="buttonAceptar" min="-2" pref="79" max="-2" attributes="0"/>
                               </Group>
                               <Group type="103" groupAlignment="0" attributes="0">
                                   <Component id="jTextFieldwebpromocion" alignment="0" min="-2" pref="274" max="-2" attributes="0"/>
                                   <Component id="jScrollPane2" min="-2" max="-2" attributes="0"/>
                               </Group>
                           </Group>
-                          <EmptySpace pref="161" max="32767" attributes="0"/>
+                          <EmptySpace pref="102" max="32767" attributes="0"/>
                       </Group>
                   </Group>
               </Group>
@@ -167,7 +170,10 @@
                               </Group>
                           </Group>
                           <EmptySpace pref="22" max="32767" attributes="0"/>
-                          <Component id="buttonAceptar" min="-2" max="-2" attributes="0"/>
+                          <Group type="103" groupAlignment="0" attributes="0">
+                              <Component id="buttonAceptar" alignment="1" min="-2" max="-2" attributes="0"/>
+                              <Component id="btnSalir" alignment="1" min="-2" max="-2" attributes="0"/>
+                          </Group>
                       </Group>
                       <Group type="102" attributes="0">
                           <EmptySpace min="0" pref="0" max="32767" attributes="0"/>
@@ -288,7 +294,7 @@
         </Component>
         <Component class="java.awt.Button" name="buttonCancelar">
           <Properties>
-            <Property name="label" type="java.lang.String" value="Cancelar"/>
+            <Property name="label" type="java.lang.String" value="Limpiar Formulario"/>
           </Properties>
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="buttonCancelarActionPerformed"/>
@@ -302,6 +308,14 @@
         <Component class="javax.swing.JTextField" name="jTextFieldcontrasena">
           <Events>
             <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="jTextFieldcontrasenaActionPerformed"/>
+          </Events>
+        </Component>
+        <Component class="java.awt.Button" name="btnSalir">
+          <Properties>
+            <Property name="label" type="java.lang.String" value="Salir"/>
+          </Properties>
+          <Events>
+            <EventHandler event="actionPerformed" listener="java.awt.event.ActionListener" parameters="java.awt.event.ActionEvent" handler="btnSalirActionPerformed"/>
           </Events>
         </Component>
       </SubComponents>

--- a/Espotify/src/espotify/presentacion/AltaPerfil.java
+++ b/Espotify/src/espotify/presentacion/AltaPerfil.java
@@ -273,16 +273,16 @@ public class AltaPerfil extends javax.swing.JInternalFrame {
             if (!destinoCarpeta.exists()) {
                 destinoCarpeta.mkdirs();
             }
-            
+
             /* Define el nuevo archivo en la carpeta de destino
                esto es lo que se guarda en la base de datos */
             File destinoArchivo;
             destinoArchivo = new File(destinoCarpeta, selectedFile.getName());
-            fotoPerfil=destinoArchivo.getPath();
+            fotoPerfil = destinoArchivo.getPath();
             try {
                 // Copia el archivo a la carpeta de destino
                 Files.copy(selectedFile.toPath(), destinoArchivo.toPath(), StandardCopyOption.REPLACE_EXISTING);
-                
+
                 // Cargar la imagen para mostrarla en el JLabel
                 Toolkit tool = Toolkit.getDefaultToolkit();
                 Image imagen = tool.createImage(ruta);
@@ -293,22 +293,6 @@ public class AltaPerfil extends javax.swing.JInternalFrame {
             }
         }
             }//GEN-LAST:event_openButtonActionPerformed
-
-    private void borrarFotoSubida() {
-        Path ruta = archivoFotoPerfil.toPath();
-        Boolean borradoExitosamente = false;
-        try {
-            borradoExitosamente = Files.deleteIfExists(ruta);
-        } catch(Exception ex) {
-            if (!borradoExitosamente) {
-                JOptionPane.showMessageDialog(
-                        null, 
-                        ex.getMessage(), 
-                        "Error", 
-                        JOptionPane.ERROR_MESSAGE);
-            }
-        }
-    }
     
     private void jComboBoxusuarioActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jComboBoxusuarioActionPerformed
         
@@ -383,6 +367,11 @@ public class AltaPerfil extends javax.swing.JInternalFrame {
             return;
         }
         
+        if (contrasena.isEmpty()) {
+            JOptionPane.showMessageDialog(null, "La contraseña esta vacia.", "Error", JOptionPane.ERROR_MESSAGE);
+            return;
+        }
+        
         if (fecNac == null) {
             JOptionPane.showMessageDialog(null, "La fecha de nacimiento esta vacio.", "Error", JOptionPane.ERROR_MESSAGE);
             return;
@@ -433,6 +422,7 @@ public class AltaPerfil extends javax.swing.JInternalFrame {
             jTextFieldnickname.setText("");
             jTextFieldnombre.setText("");
             jTextFieldapellido.setText("");
+            jTextFieldcontrasena.setText("");
             jTextFieldemail.setText("");
             jDateChooserfechaNacimiento.setDate(null);
             imageLabel.setIcon(null);
@@ -442,15 +432,15 @@ public class AltaPerfil extends javax.swing.JInternalFrame {
     }//GEN-LAST:event_buttonAceptarActionPerformed
 
     private void buttonCancelarActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_buttonCancelarActionPerformed
-             jTextFieldnickname.setText("");
+        jTextFieldnickname.setText("");
         jTextFieldnombre.setText("");
         jTextFieldapellido.setText("");
+        jTextFieldcontrasena.setText("");
         jTextFieldemail.setText("");
         jDateChooserfechaNacimiento.setDate(null);
         this.imageLabel.setIcon(null);
         jTextAreaBiografia.setText("");
         jTextFieldwebpromocion.setText("");
-        borrarFotoSubida();
     }//GEN-LAST:event_buttonCancelarActionPerformed
 
     private void jTextFieldcontrasenaActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jTextFieldcontrasenaActionPerformed
@@ -458,7 +448,6 @@ public class AltaPerfil extends javax.swing.JInternalFrame {
     }//GEN-LAST:event_jTextFieldcontrasenaActionPerformed
 
     private void btnSalirActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnSalirActionPerformed
-        borrarFotoSubida();
         this.dispose();
     }//GEN-LAST:event_btnSalirActionPerformed
 

--- a/Espotify/src/espotify/presentacion/AltaPerfil.java
+++ b/Espotify/src/espotify/presentacion/AltaPerfil.java
@@ -2,8 +2,6 @@ package espotify.presentacion;
 
 import espotify.DataTypes.DTArtista;
 import espotify.DataTypes.DTCliente;
-import espotify.logica.Artista;
-import espotify.logica.Cliente;
 import espotify.logica.Fabrica;
 import espotify.logica.IControlador;
 import java.awt.Image;
@@ -11,6 +9,7 @@ import java.awt.Toolkit;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Date;
 import java.util.regex.Pattern;
@@ -21,6 +20,7 @@ import javax.swing.filechooser.FileNameExtensionFilter;
 
 public class AltaPerfil extends javax.swing.JInternalFrame {
     private String fotoPerfil;
+    private File archivoFotoPerfil;
     private static final String EMAIL_REGEX = "^[a-zA-Z0-9_+&*-]+(?:\\.[a-zA-Z0-9_+&*-]+)*@(?:[a-zA-Z0-9-]+\\.)+[a-zA-Z]{2,7}$";
     private static final Pattern EMAIL_PATTERN = Pattern.compile(EMAIL_REGEX);
     public AltaPerfil() {
@@ -59,6 +59,7 @@ public class AltaPerfil extends javax.swing.JInternalFrame {
         buttonCancelar = new java.awt.Button();
         jLabelcontrasena = new javax.swing.JLabel();
         jTextFieldcontrasena = new javax.swing.JTextField();
+        btnSalir = new java.awt.Button();
 
         jComboBoxUsuario.setModel(new javax.swing.DefaultComboBoxModel<>(new String[] { "Item 1", "Item 2", "Item 3", "Item 4" }));
 
@@ -115,7 +116,7 @@ public class AltaPerfil extends javax.swing.JInternalFrame {
             }
         });
 
-        buttonCancelar.setLabel("Cancelar");
+        buttonCancelar.setLabel("Limpiar Formulario");
         buttonCancelar.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 buttonCancelarActionPerformed(evt);
@@ -127,6 +128,13 @@ public class AltaPerfil extends javax.swing.JInternalFrame {
         jTextFieldcontrasena.addActionListener(new java.awt.event.ActionListener() {
             public void actionPerformed(java.awt.event.ActionEvent evt) {
                 jTextFieldcontrasenaActionPerformed(evt);
+            }
+        });
+
+        btnSalir.setLabel("Salir");
+        btnSalir.addActionListener(new java.awt.event.ActionListener() {
+            public void actionPerformed(java.awt.event.ActionEvent evt) {
+                btnSalirActionPerformed(evt);
             }
         });
 
@@ -145,7 +153,8 @@ public class AltaPerfil extends javax.swing.JInternalFrame {
                     .addComponent(openButton)
                     .addComponent(jLabelBiografia)
                     .addComponent(jLabelwebpromocion)
-                    .addComponent(jLabelcontrasena))
+                    .addComponent(jLabelcontrasena)
+                    .addComponent(buttonCancelar, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
                 .addGap(34, 34, 34)
                 .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                     .addGroup(jPanel1Layout.createSequentialGroup()
@@ -161,15 +170,17 @@ public class AltaPerfil extends javax.swing.JInternalFrame {
                         .addComponent(jComboBoxusuario, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
                         .addGap(92, 92, 92))
                     .addGroup(jPanel1Layout.createSequentialGroup()
-                        .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING)
-                            .addGroup(jPanel1Layout.createSequentialGroup()
-                                .addComponent(buttonAceptar, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
-                                .addGap(155, 155, 155)
-                                .addComponent(buttonCancelar, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                        .addGap(76, 76, 76)
+                        .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.TRAILING, false)
+                            .addGroup(javax.swing.GroupLayout.Alignment.LEADING, jPanel1Layout.createSequentialGroup()
+                                .addGap(80, 80, 80)
+                                .addComponent(btnSalir, javax.swing.GroupLayout.PREFERRED_SIZE, 77, javax.swing.GroupLayout.PREFERRED_SIZE)
+                                .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, javax.swing.GroupLayout.DEFAULT_SIZE, Short.MAX_VALUE)
+                                .addComponent(buttonAceptar, javax.swing.GroupLayout.PREFERRED_SIZE, 79, javax.swing.GroupLayout.PREFERRED_SIZE))
                             .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
                                 .addComponent(jTextFieldwebpromocion, javax.swing.GroupLayout.PREFERRED_SIZE, 274, javax.swing.GroupLayout.PREFERRED_SIZE)
                                 .addComponent(jScrollPane2, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))
-                        .addContainerGap(161, Short.MAX_VALUE))))
+                        .addContainerGap(102, Short.MAX_VALUE))))
         );
         jPanel1Layout.setVerticalGroup(
             jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
@@ -215,7 +226,9 @@ public class AltaPerfil extends javax.swing.JInternalFrame {
                                 .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED)
                                 .addComponent(jTextFieldwebpromocion, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))
                         .addPreferredGap(javax.swing.LayoutStyle.ComponentPlacement.RELATED, 22, Short.MAX_VALUE)
-                        .addComponent(buttonAceptar, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE))
+                        .addGroup(jPanel1Layout.createParallelGroup(javax.swing.GroupLayout.Alignment.LEADING)
+                            .addComponent(buttonAceptar, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)
+                            .addComponent(btnSalir, javax.swing.GroupLayout.Alignment.TRAILING, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))
                     .addGroup(jPanel1Layout.createSequentialGroup()
                         .addGap(0, 0, Short.MAX_VALUE)
                         .addComponent(buttonCancelar, javax.swing.GroupLayout.PREFERRED_SIZE, javax.swing.GroupLayout.DEFAULT_SIZE, javax.swing.GroupLayout.PREFERRED_SIZE)))
@@ -257,6 +270,10 @@ public class AltaPerfil extends javax.swing.JInternalFrame {
             // Configura la carpeta de destino
             File destinoCarpeta = new File("./Resource/ImagenesPerfil");
 
+            if (!destinoCarpeta.exists()) {
+                destinoCarpeta.mkdirs();
+            }
+            
             /* Define el nuevo archivo en la carpeta de destino
                esto es lo que se guarda en la base de datos */
             File destinoArchivo;
@@ -270,13 +287,29 @@ public class AltaPerfil extends javax.swing.JInternalFrame {
                 Toolkit tool = Toolkit.getDefaultToolkit();
                 Image imagen = tool.createImage(ruta);
                 imageLabel.setIcon(new ImageIcon(imagen.getScaledInstance(imageLabel.getWidth(), imageLabel.getHeight(), Image.SCALE_AREA_AVERAGING)));
-
+                archivoFotoPerfil = destinoArchivo;
             } catch (IOException e) {
                 e.printStackTrace(); // Manejo de excepciones en caso de error al copiar
             }
         }
             }//GEN-LAST:event_openButtonActionPerformed
 
+    private void borrarFotoSubida() {
+        Path ruta = archivoFotoPerfil.toPath();
+        Boolean borradoExitosamente = false;
+        try {
+            borradoExitosamente = Files.deleteIfExists(ruta);
+        } catch(Exception ex) {
+            if (!borradoExitosamente) {
+                JOptionPane.showMessageDialog(
+                        null, 
+                        ex.getMessage(), 
+                        "Error", 
+                        JOptionPane.ERROR_MESSAGE);
+            }
+        }
+    }
+    
     private void jComboBoxusuarioActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jComboBoxusuarioActionPerformed
         
         String opcion=(String)jComboBoxusuario.getSelectedItem();
@@ -417,15 +450,21 @@ public class AltaPerfil extends javax.swing.JInternalFrame {
         this.imageLabel.setIcon(null);
         jTextAreaBiografia.setText("");
         jTextFieldwebpromocion.setText("");
-   
+        borrarFotoSubida();
     }//GEN-LAST:event_buttonCancelarActionPerformed
 
     private void jTextFieldcontrasenaActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_jTextFieldcontrasenaActionPerformed
         // TODO add your handling code here:
     }//GEN-LAST:event_jTextFieldcontrasenaActionPerformed
 
+    private void btnSalirActionPerformed(java.awt.event.ActionEvent evt) {//GEN-FIRST:event_btnSalirActionPerformed
+        borrarFotoSubida();
+        this.dispose();
+    }//GEN-LAST:event_btnSalirActionPerformed
+
 
     // Variables declaration - do not modify//GEN-BEGIN:variables
+    private java.awt.Button btnSalir;
     private java.awt.Button buttonAceptar;
     private java.awt.Button buttonCancelar;
     private javax.swing.JLabel imageLabel;


### PR DESCRIPTION
Cambios:

1: Agregue un boton para salir. 
2: Cambie el nombre de el boton Cancelar por 'Limpiar Formulario' para que sea mas claro lo que hace. 
3: Agregue un control para que cree la carpeta destino de la imagen de perfil en caso de que no exista. 
4: Agregue una funcion que elimina la foto de perfil subida que se invoca cuando se limpia el formulario o se presiona el boton de salir, asi no permanece la imagen aunque se cancele el alta.

Como se ve la GUI con los cambios:
![Screenshot from 2024-10-03 13-56-09](https://github.com/user-attachments/assets/f88e190b-3c43-4b0b-b22d-88439caea46d)
