### PR TITLE
Agregue el redireccionamiento de errores 404 y 500 hacia la pagina personalizada de errores

### DIFF
--- a/ServidorWeb/build/web/WEB-INF/web.xml
+++ b/ServidorWeb/build/web/WEB-INF/web.xml
@@ -9,4 +9,14 @@
             1440
         </session-timeout>
     </session-config>
+    
+    <error-page>
+        <error-code>404</error-code>
+        <location>/pages/ErrorPage.jsp</location>
+    </error-page>
+    
+    <error-page>
+        <error-code>500</error-code>
+        <location>/pages/ErrorPage.jsp</location>
+    </error-page>
 </web-app>

--- a/ServidorWeb/web/WEB-INF/web.xml
+++ b/ServidorWeb/web/WEB-INF/web.xml
@@ -9,4 +9,14 @@
             1440
         </session-timeout>
     </session-config>
+    
+    <error-page>
+        <error-code>404</error-code>
+        <location>/pages/ErrorPage.jsp</location>
+    </error-page>
+    
+    <error-page>
+        <error-code>500</error-code>
+        <location>/pages/ErrorPage.jsp</location>
+    </error-page>
 </web-app>

--- a/ServidorWeb/web/pages/ErrorPage.jsp
+++ b/ServidorWeb/web/pages/ErrorPage.jsp
@@ -14,9 +14,10 @@
             El mensaje de error es el de la excepcion capturada o, en caso contrario,
             un mensaje definido en el Servlet que hace el redireccionamiento.
             */
+            
             Object errCodeObj = request.getAttribute("errorCode");
             Object errCodeMsg = request.getAttribute("errorMsg");
-            
+            int responseStatus = response.getStatus();
         %>
         
         <link rel="stylesheet" href="../${pageContext.request.contextPath}/styles/variablesGlobales.css"/>
@@ -27,8 +28,23 @@
         <jsp:include page="../headerIndex.jsp"/>
 
         <section class="sectionContainer roundedContainer">
-            <h1>Error <%= errCodeObj == null ? 500 : errCodeObj.toString() %></h1>
-            <p><%= errCodeMsg == null ? "Internal Server Error" : errCodeMsg.toString()%></p>
+            <%-- 
+                Si no recibo el codigo del error desde un redirect, 
+                entonces uso el codigo designado por Tomcat 
+            --%>
+            <h1>Error <%= errCodeObj == null ? responseStatus : errCodeObj.toString() %></h1>
+            
+            <%--
+                404: Si no existe el recurso buscado Tomcat envia un response con status 404
+                Si el codigo de error no fue seteado en un redirect, entonces pongo un mensaje generico
+            --%>
+            <% if (responseStatus == 404) { %>
+                <p>Recurso no encontrado</p>
+            <% } else if (errCodeObj == null) { %>
+                <p>Error interno del servidor</p>
+            <% } else { %>
+                <p><%= errCodeMsg == null ? "Error interno del servidor" : errCodeMsg.toString() %></p>
+            <% } %>    
             <img class="errorImg" src="../${pageContext.request.contextPath}/imagenes/exclamacion.svg" alt="símbolo de exclamación"/>
         </section>
         


### PR DESCRIPTION
Agregue al web.xml la redireccion de los errores 404 y 500 hacia la pagina de error creada

Con este cambio, cuando se intenta acceder a una url de un recurso inexistente, por ejemplo /ServidorWeb/1234, o cuando ocurre un error interno en el servidor, ya no se muestra la pagina por defecto de Tomcat. En cambio se redirige a la pagina de error personalizada.

Los errores siguen apareciendo en el output log de Tomcat en la consola del IDE, pero se pierde la posibilidad de ver los mensajes y el stacktrace en la pagina misma. 
Esto es lo ideal, pero hace mas tedioso el debugging, asi que pueden comentar los tags <error-page> en el archivo WEB-INF/web.xml para continuar con el comportamiento previo.